### PR TITLE
build: support compiling with postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,16 @@ sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql
 
+ifdef USE_PGXS
 PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = contrib/pgvector
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 
 # for Mac
 ifeq ($(PROVE),)


### PR DESCRIPTION
If trying to compile this extension with postgres by placing the extension dir in postgres's contrib/ directory, make fails trying to look for pgxs in system libraries.

    Makefile:42: /usr/lib64/pgsql/pgxs/src/makefiles/pgxs.mk: No such file or directory
    make: *** No rule to make target '/usr/lib64/pgsql/pgxs/src/makefiles/pgxs.mk'.  Stop.

Many extensions (e.g. pgaudit, pg_hint_plan, pg_stat_monitor) have an if-else in their Makefile to support both compiling with PG and compiling separately.  Add similar support here.