### PR TITLE
Use isfinite rather than isnan+isinf

### DIFF
--- a/src/vector.c
+++ b/src/vector.c
@@ -74,16 +74,10 @@ CheckDim(int dim)
 static inline void
 CheckElement(float value)
 {
-	if (isnan(value))
+	if (!isfinite(value))
 		ereport(ERROR,
 				(errcode(ERRCODE_DATA_EXCEPTION),
-				 errmsg("NaN not allowed in vector")));
-
-
-	if (isinf(value))
-		ereport(ERROR,
-				(errcode(ERRCODE_DATA_EXCEPTION),
-				 errmsg("infinite value not allowed in vector")));
+				 errmsg("NaN/Inf not allowed in vector")));
 }
 
 /*


### PR DESCRIPTION
reduces the number of calls, which maybe is a useful performance nit. Probably end users do not need to know if the problem was nan or inf, just that there was a problem and it was one of those.