### PR TITLE
Link to canonical feature request for Google Cloud SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ pgvector is available on [these providers](https://github.com/pgvector/pgvector/
 
 To request a new extension on other providers:
 
-- Google Cloud SQL - vote or comment on [this page](https://issuetracker.google.com/issues/265172065)
+- Google Cloud SQL - vote or comment on [this page](https://issuetracker.google.com/issues/278521774)
 - Azure Database - vote or comment on [this page](https://feedback.azure.com/d365community/idea/7b423322-6189-ed11-a81b-000d3ae49307)
 - DigitalOcean Managed Databases - vote or comment on [this page](https://ideas.digitalocean.com/app-framework-services/p/pgvector-extension-for-postgresql)
 - Heroku Postgres - vote or comment on [this page](https://github.com/heroku/roadmap/issues/156)


### PR DESCRIPTION
Before this change, the README links to a Google Support Tracker issue that is now closed and marked as a duplicate of a different issue for requesting pgvector support. If the community would like to make its voice heard and get pgvector support in Cloud SQL, we should pipe in on the right issue. That way, their teams can prioritize knowing full well how many folks want support!