### PR TITLE
Check bounds unconditionally in array_to_vector().

### DIFF
--- a/src/vector.c
+++ b/src/vector.c
@@ -396,10 +396,8 @@ array_to_vector(PG_FUNCTION_ARGS)
 	get_typlenbyvalalign(ARR_ELEMTYPE(array), &typlen, &typbyval, &typalign);
 	deconstruct_array(array, ARR_ELEMTYPE(array), typlen, typbyval, typalign, &elemsp, &nullsp, &nelemsp);
 
-	if (typmod == -1)
-		CheckDim(nelemsp);
-	else
-		CheckExpectedDim(typmod, nelemsp);
+	CheckDim(nelemsp);
+	CheckExpectedDim(typmod, nelemsp);
 
 	result = InitVector(nelemsp);
 	for (i = 0; i < nelemsp; i++)


### PR DESCRIPTION
Presently, array_to_vector()'s call to CheckDim() is skipped when typmod != -1, which allows for bypassing VECTOR_MAX_DIM.  To fix, call Check[Expected]Dim() unconditionally.  CheckExpectedDim() takes no action when typmod == -1, so there's no need to guard it with an 'if' statement.