### PR TITLE
docs: pgvector now available on Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,6 @@ pgvector is available on [these providers](https://github.com/pgvector/pgvector/
 To request a new extension on other providers:
 
 - Google Cloud SQL - vote or comment on [this page](https://issuetracker.google.com/issues/265172065)
-- Azure Database - vote or comment on [this page](https://feedback.azure.com/d365community/idea/7b423322-6189-ed11-a81b-000d3ae49307)
 - DigitalOcean Managed Databases - vote or comment on [this page](https://ideas.digitalocean.com/managed-database/p/pgvector-extension-for-postgresql)
 - Heroku Postgres - vote or comment on [this page](https://github.com/heroku/roadmap/issues/156)
 


### PR DESCRIPTION
Available on:
- Azure Database for PostgreSQL Flexible Server
- Azure Cosmos DB for PostgreSQL