### PR TITLE
Update ivfflat cost estimation to choose index for more searches

### DIFF
--- a/src/ivfflat.c
+++ b/src/ivfflat.c
@@ -72,6 +72,7 @@ ivfflatcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 	double		ratio;
 	double		spc_seq_page_cost;
 	Relation	indexRel;
+	Cost		startupCost;
 #if PG_VERSION_NUM < 120000
 	List	   *qinfos;
 #endif
@@ -112,16 +113,18 @@ ivfflatcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 	genericcostestimate(root, path, loop_count, qinfos, &costs);
 #endif
 
+	startupCost = costs.indexTotalCost;
+
 	/* Adjust cost if needed since TOAST not included in seq scan cost */
 	if (costs.numIndexPages > path->indexinfo->rel->pages && ratio < 0.5)
 	{
 		get_tablespace_page_costs(path->indexinfo->reltablespace, NULL, &spc_seq_page_cost);
 
 		/* Change page cost from random to sequential */
-		costs.indexTotalCost -= costs.numIndexPages * (costs.spc_random_page_cost - spc_seq_page_cost);
+		startupCost -= costs.numIndexPages * (costs.spc_random_page_cost - spc_seq_page_cost);
 
 		/* Remove cost of extra pages */
-		costs.indexTotalCost -= (costs.numIndexPages - path->indexinfo->rel->pages) * spc_seq_page_cost;
+		startupCost -= (costs.numIndexPages - path->indexinfo->rel->pages) * spc_seq_page_cost;
 	}
 
 	/*
@@ -131,7 +134,7 @@ ivfflatcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 	if (ratio < costs.indexSelectivity)
 		costs.indexSelectivity = ratio;
 
-	*indexStartupCost = costs.indexTotalCost;
+	*indexStartupCost = startupCost;
 	*indexTotalCost = costs.indexTotalCost;
 	*indexSelectivity = costs.indexSelectivity;
 	*indexCorrelation = costs.indexCorrelation;


### PR DESCRIPTION
This makes several modification to the ivfflat cost estimation to help the query planner choose it for searches in appropriate situations.

First, the update costing algorithm estimates the number of pages to visit by estimating the number of tuples based on the ratio of lists to visit. Additionally, the updated costs sets the selectivity to the probe/list ratio, given we are only visiting the subset of tuples when the probe number is less than the number of lists.

With these updates, we can infer the startup cost from the generic cost estimator, as we've tuned the selectivity and page fetching values.

Testing on data sets of different size show that the query planner will choose the ivfflat index in additional appropriate situations instead of defaulting back to a sequential scan.