### PR TITLE
Fix compiler warnings on Ubuntu

### DIFF
--- a/src/ivfkmeans.c
+++ b/src/ivfkmeans.c
@@ -1,6 +1,7 @@
 #include "postgres.h"
 
 #include <float.h>
+#include <math.h>
 
 #include "ivfflat.h"
 #include "miscadmin.h"


### PR DESCRIPTION
The compiler was complaining about a missing include due to the addition of NaN/inf checks in 482a5f8b. Adding the include silences the warnings.