### PR TITLE
Modify index AM definitions to follow upstream convention

### DIFF
--- a/src/ivfbuild.c
+++ b/src/ivfbuild.c
@@ -636,7 +636,7 @@ BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo,
 /*
  * Build the index for a logged table
  */
-IndexBuildResult *
+extern IndexBuildResult *
 ivfflatbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 {
 	IndexBuildResult *result;
@@ -654,7 +654,7 @@ ivfflatbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 /*
  * Build the index for an unlogged table
  */
-void
+extern void
 ivfflatbuildempty(Relation index)
 {
 	IndexInfo  *indexInfo = BuildIndexInfo(index);

--- a/src/ivfflat.c
+++ b/src/ivfflat.c
@@ -39,7 +39,7 @@ _PG_init(void)
  * Get the name of index build phase
  */
 #if PG_VERSION_NUM >= 120000
-static char *
+extern char *
 ivfflatbuildphasename(int64 phasenum)
 {
 	switch (phasenum)
@@ -61,7 +61,7 @@ ivfflatbuildphasename(int64 phasenum)
 /*
  * Estimate the cost of an index scan
  */
-static void
+extern void
 ivfflatcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 					Cost *indexStartupCost, Cost *indexTotalCost,
 					Selectivity *indexSelectivity, double *indexCorrelation,
@@ -147,7 +147,7 @@ ivfflatcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 /*
  * Parse and validate the reloptions
  */
-static bytea *
+extern bytea *
 ivfflatoptions(Datum reloptions, bool validate)
 {
 	static const relopt_parse_elt tab[] = {
@@ -176,7 +176,7 @@ ivfflatoptions(Datum reloptions, bool validate)
 /*
  * Validate catalog entries for the specified operator class
  */
-static bool
+extern bool
 ivfflatvalidate(Oid opclassoid)
 {
 	return true;

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -232,19 +232,25 @@ void		IvfflatInitPage(Buffer buf, Page page);
 void		IvfflatInitRegisterPage(Relation index, Buffer *buf, Page *page, GenericXLogState **state);
 
 /* Index access methods */
-IndexBuildResult *ivfflatbuild(Relation heap, Relation index, IndexInfo *indexInfo);
-void		ivfflatbuildempty(Relation index);
-bool		ivfflatinsert(Relation index, Datum *values, bool *isnull, ItemPointer heap_tid, Relation heap, IndexUniqueCheck checkUnique
+extern IndexBuildResult *ivfflatbuild(Relation heap, Relation index, IndexInfo *indexInfo);
+extern void		ivfflatbuildempty(Relation index);
+extern bool		ivfflatinsert(Relation index, Datum *values, bool *isnull, ItemPointer heap_tid, Relation heap, IndexUniqueCheck checkUnique
 #if PG_VERSION_NUM >= 140000
 						  ,bool indexUnchanged
 #endif
 						  ,IndexInfo *indexInfo
 );
-IndexBulkDeleteResult *ivfflatbulkdelete(IndexVacuumInfo *info, IndexBulkDeleteResult *stats, IndexBulkDeleteCallback callback, void *callback_state);
-IndexBulkDeleteResult *ivfflatvacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats);
-IndexScanDesc ivfflatbeginscan(Relation index, int nkeys, int norderbys);
-void		ivfflatrescan(IndexScanDesc scan, ScanKey keys, int nkeys, ScanKey orderbys, int norderbys);
-bool		ivfflatgettuple(IndexScanDesc scan, ScanDirection dir);
-void		ivfflatendscan(IndexScanDesc scan);
+extern IndexBulkDeleteResult *ivfflatbulkdelete(IndexVacuumInfo *info, IndexBulkDeleteResult *stats, IndexBulkDeleteCallback callback, void *callback_state);
+extern IndexBulkDeleteResult *ivfflatvacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats);
+extern IndexScanDesc ivfflatbeginscan(Relation index, int nkeys, int norderbys);
+extern void		ivfflatrescan(IndexScanDesc scan, ScanKey keys, int nkeys, ScanKey orderbys, int norderbys);
+extern bool		ivfflatgettuple(IndexScanDesc scan, ScanDirection dir);
+extern void		ivfflatendscan(IndexScanDesc scan);
+extern void		ivfflatcostestimate(struct PlannerInfo *root, struct IndexPath *path, double loop_count, Cost *indexStartupCost, Cost *indexTotalCost, Selectivity *indexSelectivity, double *indexCorrelation, double *indexPages);
+extern bytea	*ivfflatoptions(Datum reloptions, bool validate);
+#if PG_VERSION_NUM >= 120000
+extern char		*ivfflatbuildphasename(int64 phasenum);
+#endif
+extern bool		ivfflatvalidate(Oid opclassoid);
 
 #endif

--- a/src/ivfinsert.c
+++ b/src/ivfinsert.c
@@ -179,7 +179,7 @@ InsertTuple(Relation rel, Datum *values, bool *isnull, ItemPointer heap_tid, Rel
 /*
  * Insert a tuple into the index
  */
-bool
+extern bool
 ivfflatinsert(Relation index, Datum *values, bool *isnull, ItemPointer heap_tid,
 			  Relation heap, IndexUniqueCheck checkUnique
 #if PG_VERSION_NUM >= 140000

--- a/src/ivfscan.c
+++ b/src/ivfscan.c
@@ -185,7 +185,7 @@ GetScanItems(IndexScanDesc scan, Datum value)
 /*
  * Prepare for an index scan
  */
-IndexScanDesc
+extern IndexScanDesc
 ivfflatbeginscan(Relation index, int nkeys, int norderbys)
 {
 	IndexScanDesc scan;
@@ -242,7 +242,7 @@ ivfflatbeginscan(Relation index, int nkeys, int norderbys)
 /*
  * Start or restart an index scan
  */
-void
+extern void
 ivfflatrescan(IndexScanDesc scan, ScanKey keys, int nkeys, ScanKey orderbys, int norderbys)
 {
 	IvfflatScanOpaque so = (IvfflatScanOpaque) scan->opaque;
@@ -265,7 +265,7 @@ ivfflatrescan(IndexScanDesc scan, ScanKey keys, int nkeys, ScanKey orderbys, int
 /*
  * Fetch the next tuple in the given scan
  */
-bool
+extern bool
 ivfflatgettuple(IndexScanDesc scan, ScanDirection dir)
 {
 	IvfflatScanOpaque so = (IvfflatScanOpaque) scan->opaque;
@@ -345,7 +345,7 @@ ivfflatgettuple(IndexScanDesc scan, ScanDirection dir)
 /*
  * End a scan and release resources
  */
-void
+extern void
 ivfflatendscan(IndexScanDesc scan)
 {
 	IvfflatScanOpaque so = (IvfflatScanOpaque) scan->opaque;

--- a/src/ivfvacuum.c
+++ b/src/ivfvacuum.c
@@ -7,7 +7,7 @@
 /*
  * Bulk delete tuples from the index
  */
-IndexBulkDeleteResult *
+extern IndexBulkDeleteResult *
 ivfflatbulkdelete(IndexVacuumInfo *info, IndexBulkDeleteResult *stats,
 				  IndexBulkDeleteCallback callback, void *callback_state)
 {
@@ -140,7 +140,7 @@ ivfflatbulkdelete(IndexVacuumInfo *info, IndexBulkDeleteResult *stats,
 /*
  * Clean up after a VACUUM operation
  */
-IndexBulkDeleteResult *
+extern IndexBulkDeleteResult *
 ivfflatvacuumcleanup(IndexVacuumInfo *info, IndexBulkDeleteResult *stats)
 {
 	Relation	rel = info->index;


### PR DESCRIPTION
The upstream index access methods declare them to be `extern.` While
the current definitions seem benign, this definition is needed
when an access method may be used beyond its current scope. For
example, prior to this commit, the index costing functions in
PostgreSQL would not execute the full functions due to the
`ivfflatcostestimate` not having an `extern` definition. In this case,
this would skip determining if PostgreSQL should perform a parallel
index scan.