### PR TITLE
Simplify TAP test structure to align with upstream

### DIFF
--- a/test/t/001_wal.pl
+++ b/test/t/001_wal.pl
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 31;
+use Test::More;
 
 my $dim = 32;
 
@@ -95,3 +95,5 @@ for my $i (1 .. 10)
 	);
 	test_index_replay("insert $i");
 }
+
+done_testing();

--- a/test/t/002_vacuum.pl
+++ b/test/t/002_vacuum.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 1;
+use Test::More;
 
 my $dim = 3;
 
@@ -39,3 +39,5 @@ $node->safe_psql("postgres",
 # Check size
 my $new_size = $node->safe_psql("postgres", "SELECT pg_total_relation_size('tst_v_idx');");
 is($size, $new_size, "size does not change");
+
+done_testing();

--- a/test/t/003_recall.pl
+++ b/test/t/003_recall.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 14;
+use Test::More;
 
 my $node;
 my @queries = ();
@@ -97,3 +97,5 @@ foreach (@operators) {
 	# Account for equal distances
 	test_recall(100, 0.9975, $operator);
 }
+
+done_testing();

--- a/test/t/004_centers.pl
+++ b/test/t/004_centers.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 3;
+use Test::More;
 
 # Initialize node
 my $node = get_new_node('node');
@@ -34,3 +34,5 @@ $node->safe_psql("postgres",
 
 # Test no error for duplicate centers
 test_centers(10);
+
+done_testing();

--- a/test/t/005_query_recall.pl
+++ b/test/t/005_query_recall.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 60;
+use Test::More;
 
 # Initialize node
 my $node = get_new_node('node');
@@ -43,3 +43,5 @@ foreach (@operators) {
 		is($res, $query);
 	}
 }
+
+done_testing();

--- a/test/t/006_lists.pl
+++ b/test/t/006_lists.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 3;
+use Test::More;
 
 # Initialize node
 my $node = get_new_node('node');
@@ -29,3 +29,5 @@ my ($ret, $stdout, $stderr) = $node->psql("postgres",
 	"CREATE INDEX lists10000 ON tst USING ivfflat (v) WITH (lists = 10000);"
 );
 like($stderr, qr/memory required is/);
+
+done_testing();

--- a/test/t/007_inserts.pl
+++ b/test/t/007_inserts.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 7;
+use Test::More;
 
 my $dim = 768;
 
@@ -53,3 +53,5 @@ $count = $node->safe_psql("postgres", qq(
 ));
 is($count, $expected);
 is(idx_scan(), 1);
+
+done_testing();

--- a/test/t/008_avg.pl
+++ b/test/t/008_avg.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 5;
+use Test::More;
 
 # Initialize node
 my $node = get_new_node('node');
@@ -33,3 +33,5 @@ is($avg, "[$r1,$r2,$r3]");
 # Test explain
 my $explain = $node->safe_psql("postgres", "EXPLAIN SELECT AVG(v) FROM tst;");
 like($explain, qr/Partial Aggregate/);
+
+done_testing();

--- a/test/t/009_storage.pl
+++ b/test/t/009_storage.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 1;
+use Test::More;
 
 my $dim = 1024;
 
@@ -30,3 +30,5 @@ my ($ret, $stdout, $stderr) = $node->psql("postgres",
 	"INSERT INTO tst SELECT array_agg(n), array_agg(n), array_agg(n) FROM generate_series(1, $dim) n"
 );
 like($stderr, qr/row is too big/);
+
+done_testing();


### PR DESCRIPTION
postgres/postgres@549ec20 moved to using "done_testing()" from the Perl testing framework, which removed the need to include test counts.