### PR TITLE
Index build speed optimizations

### DIFF
--- a/src/vector.c
+++ b/src/vector.c
@@ -647,11 +647,9 @@ vector_spherical_distance(PG_FUNCTION_ARGS)
 	if (dp > 1)
 		dp = 1;
 
-	distance = negate ?
-		0.5 + (dp*(0.33333333*dp + 0.16666666)):
-		0.5 - (dp*(0.33333333*dp + 0.16666666));
+	distance = dp*(dp*(1.31196852822*dp - 1.45311472663) + 0.64114619624);
 
-	PG_RETURN_FLOAT8(distance);
+	PG_RETURN_FLOAT8(negate ? 0.5 + distance : 0.5 - distance);
 }
 
 /*

--- a/src/vector.c
+++ b/src/vector.c
@@ -504,8 +504,8 @@ l2_distance(PG_FUNCTION_ARGS)
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
 	float	   *ax = a->x;
 	float	   *bx = b->x;
-	double		distance = 0.0;
-	double		diff;
+	float		distance = 0.0;
+	float		diff;
 
 	CheckDims(a, b);
 
@@ -516,7 +516,7 @@ l2_distance(PG_FUNCTION_ARGS)
 		distance += diff * diff;
 	}
 
-	PG_RETURN_FLOAT8(sqrt(distance));
+	PG_RETURN_FLOAT8(sqrt((double)distance));
 }
 
 /*
@@ -531,8 +531,8 @@ vector_l2_squared_distance(PG_FUNCTION_ARGS)
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
 	float	   *ax = a->x;
 	float	   *bx = b->x;
-	double		distance = 0.0;
-	double		diff;
+	float		distance = 0.0;
+	float		diff;
 
 	CheckDims(a, b);
 
@@ -543,7 +543,7 @@ vector_l2_squared_distance(PG_FUNCTION_ARGS)
 		distance += diff * diff;
 	}
 
-	PG_RETURN_FLOAT8(distance);
+	PG_RETURN_FLOAT8((double)distance);
 }
 
 /*
@@ -557,7 +557,7 @@ inner_product(PG_FUNCTION_ARGS)
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
 	float	   *ax = a->x;
 	float	   *bx = b->x;
-	double		distance = 0.0;
+	float		distance = 0.0;
 
 	CheckDims(a, b);
 
@@ -565,7 +565,7 @@ inner_product(PG_FUNCTION_ARGS)
 	for (int i = 0; i < a->dim; i++)
 		distance += ax[i] * bx[i];
 
-	PG_RETURN_FLOAT8(distance);
+	PG_RETURN_FLOAT8((double)distance);
 }
 
 /*
@@ -579,7 +579,7 @@ vector_negative_inner_product(PG_FUNCTION_ARGS)
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
 	float	   *ax = a->x;
 	float	   *bx = b->x;
-	double		distance = 0.0;
+	float		distance = 0.0;
 
 	CheckDims(a, b);
 
@@ -587,7 +587,7 @@ vector_negative_inner_product(PG_FUNCTION_ARGS)
 	for (int i = 0; i < a->dim; i++)
 		distance += ax[i] * bx[i];
 
-	PG_RETURN_FLOAT8(distance * -1);
+	PG_RETURN_FLOAT8((double)distance * -1);
 }
 
 /*
@@ -630,14 +630,16 @@ vector_spherical_distance(PG_FUNCTION_ARGS)
 {
 	Vector	   *a = PG_GETARG_VECTOR_P(0);
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
-	double		distance = 0.0;
+	float		dp = 0.0;
+	double		distance;
 
 	CheckDims(a, b);
 
 	/* Auto-vectorized */
 	for (int i = 0; i < a->dim; i++)
-		distance += a->x[i] * b->x[i];
+		dp += a->x[i] * b->x[i];
 
+	distance = (double) dp;
 	/* Prevent NaN with acos with loss of precision */
 	if (distance > 1)
 		distance = 1;
@@ -668,13 +670,13 @@ vector_norm(PG_FUNCTION_ARGS)
 {
 	Vector	   *a = PG_GETARG_VECTOR_P(0);
 	float	   *ax = a->x;
-	double		norm = 0.0;
+	float		norm = 0.0;
 
 	/* Auto-vectorized */
 	for (int i = 0; i < a->dim; i++)
 		norm += ax[i] * ax[i];
 
-	PG_RETURN_FLOAT8(sqrt(norm));
+	PG_RETURN_FLOAT8(sqrt((double)norm));
 }
 
 /*


### PR DESCRIPTION
When looking at the low-level ivfflat build, I saw that two things take a significant share of time:

1. Calculation of dot product
2. Caclulation of arccos value.

I did some experiments and found that I could speed up these things with a marginal precision decrease (considering that overall ivfflat is approximate and the share of exact answers in select query is significantly < 100% at any reasonable ratio of probes/lists).

The code is as follows:
https://github.com/pashkinelfe/pgvector/tree/index-build-speed-optimizations

There are two patches

1. Use float instead of double at dot product calculation. It has the most pronounced effect as dot product calculation contains floating point multiplication of all vector dimensions. Intentionally I left double the overall distance function and the calculations that are done once per vector pair (not at every dimension) as they will increase speed only marginally (and also for compatibility). The low-level reason for this speed-up is that it makes CPU (armv8) using vector multiply-add instruction (fmadd) instead of vector multiplication + conversion to double + addition (fmul + fcvt + fadd) at each vector dimension. This change can also speed up the select's speed due to faster lists traversal that includes dot product calculation to the pairs of (sample vector - index vector).

2. Caclulate arccos value for spherical big circle distance as a quadratic Lagrange approximation plus sign extension. The effect of this is less pronounced so it could decided to be merged separately.

Overall performance measurements are done at original state (arccos + double dot product), first patch (arccos + float), second (Lagrange approximation + double) and both (Lagrange approximation + float). The dataset is a real 900K sized set of OpenAI vectors (https://huggingface.co/datasets/KShivendu/dbpedia-entities-openai-1M), but the same results are also for random 900K set. Number of lists are chosen at recommended value (900) and 3 time recommended and 1/3 times recommended. The most pronounced effect (55% index build time decrease) is when the number of lists is more than recommended, which has a good reason to be build to increase select speed at cost of index build time. But for recommended value the effect is also very pronounced i.e. 30% index build time decrease with both patches.

Absolute index build times:
<img width="728" alt="image" src="https://github.com/pgvector/pgvector/assets/63344111/1cb40bf6-d58e-4d74-84c4-5c49f5ef9e3e">

Relative index build times as a ratio to original unpatched code:
<img width="719" alt="image" src="https://github.com/pgvector/pgvector/assets/63344111/24696876-69e4-4cfe-bb5c-430d1e19b4f7">

Regarding index quality, I consider that these small changes in distance calculations will not be so pronounced to be seen on precision vs probes/lists plot as in https://github.com/pgvector/pgvector/issues/163#issuecomment-1603041726 or https://github.com/erikbern/ann-benchmarks. I don't expect seeing any changes in precision vs probes/lists or qps plot for selects performance. Still I'll try to publish these benchmarks for all patch variants vs current state.