### PR TITLE
Speed up ivfflat build: use float instead of double for dot product

### DIFF
--- a/src/vector.c
+++ b/src/vector.c
@@ -504,8 +504,8 @@ l2_distance(PG_FUNCTION_ARGS)
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
 	float	   *ax = a->x;
 	float	   *bx = b->x;
-	double		distance = 0.0;
-	double		diff;
+	float		distance = 0.0;
+	float		diff;
 
 	CheckDims(a, b);
 
@@ -516,7 +516,7 @@ l2_distance(PG_FUNCTION_ARGS)
 		distance += diff * diff;
 	}
 
-	PG_RETURN_FLOAT8(sqrt(distance));
+	PG_RETURN_FLOAT8(sqrt((double)distance));
 }
 
 /*
@@ -531,8 +531,8 @@ vector_l2_squared_distance(PG_FUNCTION_ARGS)
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
 	float	   *ax = a->x;
 	float	   *bx = b->x;
-	double		distance = 0.0;
-	double		diff;
+	float		distance = 0.0;
+	float		diff;
 
 	CheckDims(a, b);
 
@@ -543,7 +543,7 @@ vector_l2_squared_distance(PG_FUNCTION_ARGS)
 		distance += diff * diff;
 	}
 
-	PG_RETURN_FLOAT8(distance);
+	PG_RETURN_FLOAT8((double)distance);
 }
 
 /*
@@ -557,7 +557,7 @@ inner_product(PG_FUNCTION_ARGS)
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
 	float	   *ax = a->x;
 	float	   *bx = b->x;
-	double		distance = 0.0;
+	float		distance = 0.0;
 
 	CheckDims(a, b);
 
@@ -565,7 +565,7 @@ inner_product(PG_FUNCTION_ARGS)
 	for (int i = 0; i < a->dim; i++)
 		distance += ax[i] * bx[i];
 
-	PG_RETURN_FLOAT8(distance);
+	PG_RETURN_FLOAT8((double)distance);
 }
 
 /*
@@ -579,7 +579,7 @@ vector_negative_inner_product(PG_FUNCTION_ARGS)
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
 	float	   *ax = a->x;
 	float	   *bx = b->x;
-	double		distance = 0.0;
+	float		distance = 0.0;
 
 	CheckDims(a, b);
 
@@ -587,7 +587,7 @@ vector_negative_inner_product(PG_FUNCTION_ARGS)
 	for (int i = 0; i < a->dim; i++)
 		distance += ax[i] * bx[i];
 
-	PG_RETURN_FLOAT8(distance * -1);
+	PG_RETURN_FLOAT8((double)distance * -1);
 }
 
 /*
@@ -630,14 +630,16 @@ vector_spherical_distance(PG_FUNCTION_ARGS)
 {
 	Vector	   *a = PG_GETARG_VECTOR_P(0);
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
-	double		distance = 0.0;
+	float		dp = 0.0;
+	double		distance;
 
 	CheckDims(a, b);
 
 	/* Auto-vectorized */
 	for (int i = 0; i < a->dim; i++)
-		distance += a->x[i] * b->x[i];
+		dp += a->x[i] * b->x[i];
 
+	distance = (double) dp;
 	/* Prevent NaN with acos with loss of precision */
 	if (distance > 1)
 		distance = 1;
@@ -668,13 +670,13 @@ vector_norm(PG_FUNCTION_ARGS)
 {
 	Vector	   *a = PG_GETARG_VECTOR_P(0);
 	float	   *ax = a->x;
-	double		norm = 0.0;
+	float		norm = 0.0;
 
 	/* Auto-vectorized */
 	for (int i = 0; i < a->dim; i++)
 		norm += ax[i] * ax[i];
 
-	PG_RETURN_FLOAT8(sqrt(norm));
+	PG_RETURN_FLOAT8(sqrt((double)norm));
 }
 
 /*


### PR DESCRIPTION
This is the first patch of patchset https://github.com/pgvector/pgvector/pull/178 as requested in the comments https://github.com/pgvector/pgvector/pull/178#issuecomment-1622886656

Regarding the conversion of the distance functions interface from double to float it will need modification of vector.sql interface which may need a major extension upgrade. If we're ready for this, I'd easily modify the patch as requested in https://github.com/pgvector/pgvector/pull/178#issuecomment-1622886656 As of now I've left it as is for compatibility, and as this modifications will not make it much faster to build ivfflat index.