### PR TITLE
Added bound option [skip ci]

### DIFF
--- a/src/ivfflat.c
+++ b/src/ivfflat.c
@@ -14,6 +14,7 @@
 #endif
 
 int			ivfflat_probes;
+int			ivfflat_bound;
 static relopt_kind ivfflat_relopt_kind;
 
 /*
@@ -33,6 +34,10 @@ IvfflatInit(void)
 	DefineCustomIntVariable("ivfflat.probes", "Sets the number of probes",
 							"Valid range is 1..lists.", &ivfflat_probes,
 							1, 1, IVFFLAT_MAX_LISTS, PGC_USERSET, 0, NULL, NULL, NULL);
+
+	DefineCustomIntVariable("ivfflat.bound", "Sets the max results from index (experimental)",
+							NULL, &ivfflat_bound,
+							0, 0, INT_MAX, PGC_USERSET, 0, NULL, NULL, NULL);
 }
 
 /*

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -83,6 +83,7 @@
 
 /* Variables */
 extern int	ivfflat_probes;
+extern int	ivfflat_bound;
 
 typedef struct VectorArrayData
 {

--- a/src/ivfscan.c
+++ b/src/ivfscan.c
@@ -125,6 +125,10 @@ GetScanItems(IndexScanDesc scan, Datum value)
 	 */
 	BufferAccessStrategy bas = GetAccessStrategy(BAS_BULKREAD);
 
+	/* Set the max number of results */
+	if (ivfflat_bound > 0)
+		tuplesort_set_bound(so->sortstate, ivfflat_bound);
+
 	/* Search closest probes lists */
 	while (!pairingheap_is_empty(so->listQueue))
 	{


### PR DESCRIPTION
bound3 is a rebased bound2 on the current master. Some benchmarks:
1. Ann benchmark (added bound patch measurements to existing ones)
Bound patch almost entirely repeats pgvector-float patch from measurements as pgvector-float patch is already in the master branch, the current bound3 is based on.
<img width="1147" alt="image" src="https://github.com/pgvector/pgvector/assets/63344111/f3b17cdb-6e61-448a-8bf6-eb45666c3675">


3. Manual select speed test on 900K rows from 1M_openai_embeddings dataset with an increased number of probes = 250 (lists = 2000) 
`select id from emb order by vector <#> (select vector from emb_query order by random() limit 1) limit 10;`

Increased number of probes/lists make select scans sort more rows each time, and that's the scenario where we can gain from bounded sort. Actual number of lists in the scan would be 900000/2000*250 = 112500

The results of 20 selects for bound 0 (=no bound) and bound 10 in interleaved order.
<img width="642" alt="image" src="https://github.com/pgvector/pgvector/assets/63344111/8b32aa96-8cd5-43c4-91d1-589cea82711d">

Without bound some measurements in a series are significantly slower. Overall average time is 0.28s (bound 10) vs 0.34s (bound 0 = no bound). It's not so impressive gain and got at bigger than recommended number of lists. Though it's not worse and could be merged IMO. 

I guess are there conditions where the effect from bound sort would be more pronounced?