### PR TITLE
Add Alpine Dockerfile

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,16 @@
+ARG PG_MAJOR=15
+
+FROM postgres:${PG_MAJOR}-alpine
+ARG PG_MAJOR
+
+COPY . /tmp/pgvector
+
+RUN apk add --no-cache build-base clang15 llvm15 postgresql${PG_MAJOR}-dev && \
+	cd /tmp/pgvector && \
+	make clean && \
+	make OPTFLAGS="" && \
+	make install && \
+	mkdir -p /usr/share/doc/pgvector && \
+	cp LICENSE README.md /usr/share/doc/pgvector && \
+	apk del --no-cache build-base clang15 llvm15 postgresql${PG_MAJOR}-dev && \
+	rm -r /tmp/pgvector

--- a/README.md
+++ b/README.md
@@ -423,6 +423,14 @@ cd pgvector
 docker build --build-arg PG_MAJOR=15 -t myuser/pgvector .
 ```
 
+The default image is based on Debian 11 (bullseye). To build an [Alpine](https://www.alpinelinux.org/) image, use `Dockerfile.alpine`:
+
+```sh
+git clone --branch v0.4.4 https://github.com/pgvector/pgvector.git
+cd pgvector
+docker build --build-arg PG_MAJOR=15 -t myuser/pgvector -f Dockerfile.alpine .
+```
+
 ### Homebrew
 
 With Homebrew Postgres, you can use:


### PR DESCRIPTION
This adds a Dockerfile for creating an Alpine build. The resulting image is ~80MB smaller than the Debian image.