### PR TITLE
Enable pgvetor to support order by null

### DIFF
--- a/test/expected/ivfflat_cosine.out
+++ b/test/expected/ivfflat_cosine.out
@@ -12,8 +12,11 @@ SELECT * FROM t ORDER BY val <=> '[3,3,3]';
 (3 rows)
 
 SELECT * FROM t ORDER BY val <=> (SELECT NULL::vector);
- val 
------
-(0 rows)
+   val   
+---------
+ [1,2,3]
+ [1,1,1]
+ [1,2,4]
+(3 rows)
 
 DROP TABLE t;

--- a/test/expected/ivfflat_ip.out
+++ b/test/expected/ivfflat_ip.out
@@ -13,8 +13,12 @@ SELECT * FROM t ORDER BY val <#> '[3,3,3]';
 (4 rows)
 
 SELECT * FROM t ORDER BY val <#> (SELECT NULL::vector);
- val 
------
-(0 rows)
+   val   
+---------
+ [0,0,0]
+ [1,2,3]
+ [1,1,1]
+ [1,2,4]
+(4 rows)
 
 DROP TABLE t;

--- a/test/expected/ivfflat_l2.out
+++ b/test/expected/ivfflat_l2.out
@@ -13,9 +13,13 @@ SELECT * FROM t ORDER BY val <-> '[3,3,3]';
 (4 rows)
 
 SELECT * FROM t ORDER BY val <-> (SELECT NULL::vector);
- val 
------
-(0 rows)
+   val   
+---------
+ [0,0,0]
+ [1,2,3]
+ [1,1,1]
+ [1,2,4]
+(4 rows)
 
 SELECT COUNT(*) FROM t;
  count 


### PR DESCRIPTION
Now, when the ORDER BY value is null, the scan with ivfflat index will return nothing, which is different with seq scan.

For instance:
SELECT * FROM t ORDER BY val <=> (SELECT NULL::vector);