### PR TITLE
Make pgvector headers available to others.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ MODULE_big = vector
 DATA = $(wildcard sql/*--*.sql)
 OBJS = src/hnsw.o src/hnswbuild.o src/hnswinsert.o src/hnswscan.o src/hnswutils.o src/hnswvacuum.o src/ivfbuild.o src/ivfflat.o src/ivfinsert.o src/ivfkmeans.o src/ivfscan.o src/ivfutils.o src/ivfvacuum.o src/vector.o
 
+HEADERS_vector = src/vector.h src/ivfflat.h
+
 TESTS = $(wildcard test/sql/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test --load-extension=vector

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MODULE_big = vector
 DATA = $(wildcard sql/*--*.sql)
 OBJS = src/hnsw.o src/hnswbuild.o src/hnswinsert.o src/hnswscan.o src/hnswutils.o src/hnswvacuum.o src/ivfbuild.o src/ivfflat.o src/ivfinsert.o src/ivfkmeans.o src/ivfscan.o src/ivfutils.o src/ivfvacuum.o src/vector.o
 
-HEADERS_vector = src/vector.h src/ivfflat.h
+HEADERS_vector = src/vector.h
 
 TESTS = $(wildcard test/sql/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))


### PR DESCRIPTION
This makes  ` pgvector` headers available to other Postgres extensions, like ` #include "extension/vector/vector.h"`