### PR TITLE
Ivfflat column dimension must be greater than 0

### DIFF
--- a/src/ivfbuild.c
+++ b/src/ivfbuild.c
@@ -355,7 +355,7 @@ InitBuildState(IvfflatBuildState * buildstate, Relation heap, Relation index, In
 	buildstate->dimensions = TupleDescAttr(index->rd_att, 0)->atttypmod;
 
 	/* Require column to have dimensions to be indexed */
-	if (buildstate->dimensions < 0)
+	if (buildstate->dimensions <= 0)
 		elog(ERROR, "column does not have dimensions");
 
 	if (buildstate->dimensions > IVFFLAT_MAX_DIM)


### PR DESCRIPTION
InitBuildState for the ivfflat index checks that the dimension of the column to be indexed has a dimension greater than or equal 0. However a vector cannot have a dimension of 0. 

Adjust the check in InitBuildState to follow the vector input logic which requires at least one dimension.