### PR TITLE
Ivfflat index only supports scans with MVCC-compliant snapshots

### DIFF
--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -248,6 +248,7 @@ typedef struct IvfflatScanOpaqueData
 	bool		first;
 	BlockNumber indexblkno;
 	ItemPointerData heaptid;
+	XLogRecPtr	pagelsn;
 
 	/* Sorting */
 	Tuplesortstate *sortstate;

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -246,7 +246,7 @@ typedef struct IvfflatScanOpaqueData
 	int			probes;
 	int			dimensions;
 	bool		first;
-	Buffer		buf;
+	BlockNumber indexblkno;
 	ItemPointerData heaptid;
 
 	/* Sorting */

--- a/src/ivfscan.c
+++ b/src/ivfscan.c
@@ -207,8 +207,8 @@ MarkPriorTupleDead(IndexScanDesc scan)
 			XLogRecPtrIsInvalid(so->pagelsn))
 		return;
 
-	/* Only a shared locked is needed for ItemIdMarkDead */
 	buf = ReadBuffer(scan->indexRelation, so->indexblkno);
+	/* Only a shared locked is needed for ItemIdMarkDead */
 	LockBuffer(buf, BUFFER_LOCK_SHARE);
 	page = BufferGetPage(buf);
 	maxoffno = PageGetMaxOffsetNumber(page);
@@ -367,6 +367,10 @@ ivfflatgettuple(IndexScanDesc scan, ScanDirection dir)
 		/* Safety check */
 		if (scan->orderByData == NULL)
 			elog(ERROR, "cannot scan ivfflat index without order");
+
+		/* Safety check */
+		if (!IsMVCCSnapshot(scan->xs_snapshot))
+			elog(ERROR, "non-MVCC snapshots are not supported with ivfflat");
 
 		if (scan->orderByData->sk_flags & SK_ISNULL)
 			value = PointerGetDatum(InitVector(so->dimensions));


### PR DESCRIPTION
Ivfflat index firstly fetch all index tuples which match the scan keys, and sort those tuples by distance. Then, fetch the heap tuples by tid. So the ivfflat index scans are asynchronous, which means it is only workable for a query using an MVCC snapshot.

This pr can improve the performance as it doesn't read and lock the buffer each time before fetching the heap tuple.  And it is not necessary for ivfflat to support non-MVCC snapshot.