### PR TITLE
Retry search with increased ef_search to provide more results needed for filtering

### DIFF
--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -14,6 +14,7 @@
 #endif
 
 int			hnsw_ef_search;
+int			hnsw_max_ef_search;
 static relopt_kind hnsw_relopt_kind;
 
 /*
@@ -39,6 +40,9 @@ HnswInit(void)
 	DefineCustomIntVariable("hnsw.ef_search", "Sets the size of the dynamic candidate list for search",
 							"Valid range is 1..1000.", &hnsw_ef_search,
 							HNSW_DEFAULT_EF_SEARCH, HNSW_MIN_EF_SEARCH, HNSW_MAX_EF_SEARCH, PGC_USERSET, 0, NULL, NULL, NULL);
+	DefineCustomIntVariable("hnsw.max_ef_search", "Maximal value of ef_search used to repeat scan if more candidates are needed",
+							"Valid range is 0..MAX_INT, 0 means that there isnot limit.", &hnsw_max_ef_search,
+							HNSW_MAX_EF_SEARCH*1000, 0, INT_MAX, PGC_USERSET, 0, NULL, NULL, NULL);
 }
 
 /*

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -221,6 +221,11 @@ typedef struct HnswScanOpaqueData
 	List	   *w;
 	MemoryContext tmpCtx;
 
+	int			ef_search;
+	bool		has_more_results;
+	ItemPointer	results;
+	size_t		n_results;
+
 	/* Support functions */
 	FmgrInfo   *procinfo;
 	FmgrInfo   *normprocinfo;

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -88,6 +88,7 @@
 
 /* Variables */
 extern int	hnsw_ef_search;
+extern int	hnsw_max_ef_search;
 
 typedef struct HnswNeighborArray HnswNeighborArray;
 

--- a/src/hnswscan.c
+++ b/src/hnswscan.c
@@ -305,7 +305,7 @@ hnswgettuple(IndexScanDesc scan, ScanDirection dir)
 	}
 
 	/* Try to search more condidates */
-	if (so->has_more_results)
+	if (so->has_more_results && (hnsw_max_ef_search == 0 || so->ef_search < hnsw_max_ef_search))
 	{
 		so->ef_search *= 2;
 		FreeItems(so->w);

--- a/src/hnswscan.c
+++ b/src/hnswscan.c
@@ -102,7 +102,11 @@ FilterResults(List* items, ItemPointer results, size_t n_results)
 			ItemPointer heaptid = (ItemPointer) lfirst(c2);
 			if (bsearch(heaptid, results, n_results, sizeof(ItemPointerData), (int (*)(const void *, const void *))ItemPointerCompare))
 			{
+#if PG_VERSION_NUM >= 130000
 				hc->element->heaptids = foreach_delete_current(hc->element->heaptids, c2);
+#else
+				hc->element->heaptids = list_delete_cell(hc->element->heaptids, c2);
+#endif
 			}
 		}
 	}

--- a/src/hnswscan.c
+++ b/src/hnswscan.c
@@ -102,7 +102,7 @@ FilterResults(List* items, ItemPointer results, size_t n_results)
 			ItemPointer heaptid = (ItemPointer) lfirst(c2);
 			if (bsearch(heaptid, results, n_results, sizeof(ItemPointerData), (int (*)(const void *, const void *))ItemPointerCompare))
 			{
-				hc->element->heaptids = list_delete_cell(hc->element->heaptids, c2);
+				hc->element->heaptids = foreach_delete_current(hc->element->heaptids, c2);
 			}
 		}
 	}
@@ -214,8 +214,6 @@ hnswgettuple(IndexScanDesc scan, ScanDirection dir)
 	Datum		value;
 	HnswScanOpaque so = (HnswScanOpaque) scan->opaque;
 	MemoryContext oldCtx = MemoryContextSwitchTo(so->tmpCtx);
-	ItemPointer prev_results = NULL;
-	size_t prev_n_results;
 
 	/*
 	 * Index can be used to scan backward, but Postgres doesn't support
@@ -240,20 +238,20 @@ hnswgettuple(IndexScanDesc scan, ScanDirection dir)
 
 		so->w = GetScanItems(scan, value);
 		so->has_more_results = list_length(so->w) >= so->ef_search;
-		prev_results = so->results;
-		prev_n_results = so->n_results;
-		if (so->has_more_results)
-		{
-			so->n_results = CountResults(so->w);
-			so->results = palloc(so->n_results * sizeof(ItemPointerData));
-			ExtractResults(so->w, so->results);
-		}
-		if (prev_results)
+		if (so->results)
 		{
 			/* Sort for binary search */
-			pg_qsort(prev_results, prev_n_results, sizeof(ItemPointerData), (int (*)(const void *, const void *))ItemPointerCompare);
-			FilterResults(so->w, prev_results, prev_n_results);
-			pfree(prev_results);
+			pg_qsort(so->results, so->n_results, sizeof(ItemPointerData), (int (*)(const void *, const void *))ItemPointerCompare);
+			FilterResults(so->w, so->results, so->n_results);
+		}
+		if (so->has_more_results)
+		{
+			size_t more_results = CountResults(so->w);
+			so->results = so->results
+				? repalloc(so->results, (so->n_results + more_results) * sizeof(ItemPointerData))
+				: palloc(more_results * sizeof(ItemPointerData));
+			ExtractResults(so->w, so->results + so->n_results);
+			so->n_results += more_results;
 		}
 	}
 

--- a/src/hnswscan.c
+++ b/src/hnswscan.c
@@ -102,7 +102,7 @@ FilterResults(List* items, ItemPointer results, size_t n_results)
 			ItemPointer heaptid = (ItemPointer) lfirst(c2);
 			if (bsearch(heaptid, results, n_results, sizeof(ItemPointerData), (int (*)(const void *, const void *))ItemPointerCompare))
 			{
-				(void)list_delete_cell(hc->element->heaptids, c2);
+				hc->element->heaptids = list_delete_cell(hc->element->heaptids, c2);
 			}
 		}
 	}

--- a/test/t/015_hnsw_duplicates.pl
+++ b/test/t/015_hnsw_duplicates.pl
@@ -28,7 +28,7 @@ sub test_duplicates
 		SET hnsw.ef_search = 1;
 		SELECT COUNT(*) FROM (SELECT * FROM tst ORDER BY v <-> '[1,1,1]') t;
 	));
-	is($res, 10);
+	is($res, 20);
 }
 
 # Test duplicates with build


### PR DESCRIPTION
See #259 

Unlike R-Tree KNN search, it is not possible to provide iterator for HNSW index which returns all tuples in distance descending order. Number of search results is limited by `ef_search` parameter.

The simplest (but certainly not efficient) solution is to repeat search with larger `ef_search` value.
This approach is implemented by this PR. If `limit` clause or filter condition in query requires more candidates than provided with `hnsw_ef_search` value, then search is repeated with doubled value of  this parameter.