### PR TITLE
Include `ItemIdData` when computing the maxSize for the data in a page

### DIFF
--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -117,7 +117,7 @@ CreateElementPages(HnswBuildState * buildstate)
 	ListCell   *lc;
 
 	/* Calculate sizes */
-	maxSize = BLCKSZ - MAXALIGN(SizeOfPageHeaderData) - MAXALIGN(sizeof(HnswPageOpaqueData));
+	maxSize = BLCKSZ - MAXALIGN(SizeOfPageHeaderData) - MAXALIGN(sizeof(HnswPageOpaqueData)) - sizeof(ItemIdData);
 	etupSize = HNSW_ELEMENT_TUPLE_SIZE(dimensions);
 
 	/* Allocate once */

--- a/src/hnswinsert.c
+++ b/src/hnswinsert.c
@@ -135,7 +135,7 @@ WriteNewElementPages(Relation index, HnswElement e, int m, BlockNumber insertPag
 	etupSize = HNSW_ELEMENT_TUPLE_SIZE(dimensions);
 	ntupSize = HNSW_NEIGHBOR_TUPLE_SIZE(e->level, m);
 	combinedSize = etupSize + ntupSize + sizeof(ItemIdData);
-	maxSize = BLCKSZ - MAXALIGN(SizeOfPageHeaderData) - MAXALIGN(sizeof(HnswPageOpaqueData));
+	maxSize = BLCKSZ - MAXALIGN(SizeOfPageHeaderData) - MAXALIGN(sizeof(HnswPageOpaqueData)) - sizeof(ItemIdData);
 	minCombinedSize = etupSize + HNSW_NEIGHBOR_TUPLE_SIZE(0, m) + sizeof(ItemIdData);
 
 	/* Prepare element tuple */

--- a/src/ivfinsert.c
+++ b/src/ivfinsert.c
@@ -99,7 +99,7 @@ InsertTuple(Relation index, Datum *values, bool *isnull, ItemPointer heap_tid, R
 
 	/* Get tuple size */
 	itemsz = MAXALIGN(IndexTupleSize(itup));
-	Assert(itemsz <= BLCKSZ - MAXALIGN(SizeOfPageHeaderData) - MAXALIGN(sizeof(IvfflatPageOpaqueData)));
+	Assert(itemsz <= BLCKSZ - MAXALIGN(SizeOfPageHeaderData) - MAXALIGN(sizeof(IvfflatPageOpaqueData)) - sizeof(ItemIdData));
 
 	/* Find a page to insert the item */
 	for (;;)


### PR DESCRIPTION
As the data is aligned, for hnsw, the combined size won't be in the range (8156 (maxSize exlucding `ItemIdData`), 8160]. So even if the ItemIdData is not included in the maxSize, it works well now, but I think it's better to make it correct.