### PR TITLE
Hnsw iterator

### DIFF
--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -15,6 +15,7 @@
 
 int			hnsw_ef_search;
 bool		hnsw_enable_iterator;
+bool		hnsw_strict_order;
 static relopt_kind hnsw_relopt_kind;
 
 /*
@@ -43,6 +44,9 @@ HnswInit(void)
 	DefineCustomBoolVariable("hnsw.enable_iterator", "Use iterator to support filtering",
 							 NULL, &hnsw_enable_iterator,
 							 true, PGC_USERSET, 0, NULL, NULL, NULL);
+	DefineCustomBoolVariable("hnsw.strict_order", "Provide string order of returned results in HNSW iterator",
+							 "Skip results with violates distance order", &hnsw_strict_order,
+							 false, PGC_USERSET, 0, NULL, NULL, NULL);
 }
 
 /*

--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -14,6 +14,7 @@
 #endif
 
 int			hnsw_ef_search;
+bool		hnsw_enable_iterator;
 static relopt_kind hnsw_relopt_kind;
 
 /*
@@ -39,6 +40,9 @@ HnswInit(void)
 	DefineCustomIntVariable("hnsw.ef_search", "Sets the size of the dynamic candidate list for search",
 							"Valid range is 1..1000.", &hnsw_ef_search,
 							HNSW_DEFAULT_EF_SEARCH, HNSW_MIN_EF_SEARCH, HNSW_MAX_EF_SEARCH, PGC_USERSET, 0, NULL, NULL, NULL);
+	DefineCustomBoolVariable("hnsw.enable_iterator", "Use iterator to support filtering",
+							 NULL, &hnsw_enable_iterator,
+							 true, PGC_USERSET, 0, NULL, NULL, NULL);
 }
 
 /*

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -88,6 +88,7 @@
 
 /* Variables */
 extern int	hnsw_ef_search;
+extern bool hnsw_enable_iterator;
 
 typedef struct HnswNeighborArray HnswNeighborArray;
 
@@ -221,11 +222,13 @@ typedef struct
 	pairingheap *W;
 	HTAB*        v;
 	int          n;
+	float        distance;
 } LayerScanDesc;
 
 typedef struct HnswScanOpaqueData
 {
 	bool		first;
+	List	   *w;
 	MemoryContext tmpCtx;
 
 	LayerScanDesc* layers;

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -222,7 +222,6 @@ typedef struct
 	pairingheap *W;
 	HTAB*        v;
 	int          n;
-	float        distance;
 } LayerScanDesc;
 
 typedef struct HnswScanOpaqueData

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -222,6 +222,7 @@ typedef struct
 	pairingheap *W;
 	HTAB*        v;
 	int          n;
+	float        max_distance;
 } LayerScanDesc;
 
 typedef struct HnswScanOpaqueData

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -215,13 +215,26 @@ typedef struct HnswNeighborTupleData
 
 typedef HnswNeighborTupleData * HnswNeighborTuple;
 
+typedef struct
+{
+	pairingheap *C;
+	pairingheap *W;
+	HTAB*        v;
+	int          n;
+} LayerScanDesc;
+
 typedef struct HnswScanOpaqueData
 {
 	bool		first;
-	List	   *w;
 	MemoryContext tmpCtx;
 
-	/* Support functions */
+	LayerScanDesc* layers;
+	int			n_layers;
+	int         m;
+	Datum       q;
+	HnswCandidate *hc;
+
+    /* Support functions */
 	FmgrInfo   *procinfo;
 	FmgrInfo   *normprocinfo;
 	Oid			collation;
@@ -285,6 +298,8 @@ void		HnswLoadElement(HnswElement element, float *distance, Datum *q, Relation i
 void		HnswSetElementTuple(HnswElementTuple etup, HnswElement element);
 void		HnswUpdateConnection(HnswElement element, HnswCandidate * hc, int m, int lc, int *updateIdx, Relation index, FmgrInfo *procinfo, Oid collation);
 void		HnswLoadNeighbors(HnswElement element, Relation index, int m);
+HnswCandidate* HnswGetNext(IndexScanDesc scan);
+void		HnswInitScan(IndexScanDesc scan, Datum q);
 
 /* Index access methods */
 IndexBuildResult *hnswbuild(Relation heap, Relation index, IndexInfo *indexInfo);

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -222,7 +222,6 @@ typedef struct
 	pairingheap *W;
 	HTAB*        v;
 	int          n;
-	float        max_distance;
 } LayerScanDesc;
 
 typedef struct HnswScanOpaqueData

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -89,6 +89,7 @@
 /* Variables */
 extern int	hnsw_ef_search;
 extern bool hnsw_enable_iterator;
+extern bool hnsw_strict_order;
 
 typedef struct HnswNeighborArray HnswNeighborArray;
 
@@ -234,6 +235,7 @@ typedef struct HnswScanOpaqueData
 	int			n_layers;
 	int         m;
 	Datum       q;
+	float       last_distance;
 	HnswCandidate *hc;
 
     /* Support functions */

--- a/src/hnswscan.c
+++ b/src/hnswscan.c
@@ -186,7 +186,7 @@ hnswgettuple(IndexScanDesc scan, ScanDirection dir)
 					if (hc == NULL)
 						break;
 				}
-				while (hnsw_strict_order && hc->distance > so->last_distance);
+				while (hnsw_strict_order && hc->distance < so->last_distance);
 				so->last_distance = hc->distance;
 				so->hc = hc;
 			}

--- a/src/hnswscan.c
+++ b/src/hnswscan.c
@@ -164,6 +164,7 @@ hnswgettuple(IndexScanDesc scan, ScanDirection dir)
 		/* Move to next element if no valid heap TIDs */
 		if (list_length(hc->element->heaptids) == 0)
 		{
+			so->hc = NULL;
 			continue;
 		}
 

--- a/src/hnswscan.c
+++ b/src/hnswscan.c
@@ -167,7 +167,7 @@ hnswgettuple(IndexScanDesc scan, ScanDirection dir)
 		else
 			so->w = GetScanItems(scan, value);
 
-		so->last_distance = FLT_MAX;
+		so->last_distance = 0;
 		so->first = false;
 	}
 
@@ -187,6 +187,10 @@ hnswgettuple(IndexScanDesc scan, ScanDirection dir)
 						break;
 				}
 				while (hnsw_strict_order && hc->distance < so->last_distance);
+
+				if (hc == NULL)
+					break;
+
 				so->last_distance = hc->distance;
 				so->hc = hc;
 			}

--- a/src/hnswscan.c
+++ b/src/hnswscan.c
@@ -132,16 +132,7 @@ hnswgettuple(IndexScanDesc scan, ScanDirection dir)
 		/* Get scan value */
 		value = GetScanValue(scan);
 
-		/*
-		 * Get a shared lock. This allows vacuum to ensure no in-flight scans
-		 * before marking tuples as deleted.
-		 */
-		LockPage(scan->indexRelation, HNSW_SCAN_LOCK, ShareLock);
-
 		HnswInitScan(scan, value);
-
-		/* Release shared lock */
-		UnlockPage(scan->indexRelation, HNSW_SCAN_LOCK, ShareLock);
 
 		so->first = false;
 	}
@@ -153,9 +144,7 @@ hnswgettuple(IndexScanDesc scan, ScanDirection dir)
 		hc = so->hc;
 		if (hc == NULL)
 		{
-			LockPage(scan->indexRelation, HNSW_SCAN_LOCK, ShareLock);
 			hc = HnswGetNext(scan);
-			UnlockPage(scan->indexRelation, HNSW_SCAN_LOCK, ShareLock);
 			if (hc == NULL)
 				break;
 			so->hc = hc;

--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -690,7 +690,6 @@ MoreCandidates(IndexScanDesc scan, int lc, int ef)
 				layer->n += lc != 0 || list_length(ec->element->heaptids) != 0;
 			}
 		}
-		return true;
 	}
 	return false;
 }

--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -1,6 +1,5 @@
 #include "postgres.h"
 
-#include <float.h>
 #include <math.h>
 
 #include "access/relscan.h"
@@ -626,7 +625,7 @@ HnswInitScan(IndexScanDesc scan, Datum q)
 		so->layers[i].W = pairingheap_allocate(CompareNearestCandidates, NULL);
 		so->layers[i].v = hash_create("hnsw visited", 256, &hash_ctl, HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 		so->layers[i].n = 0;
-		so->layers[i].max_distance = FLT_MAX;
+		so->layers[i].max_distance = 0;
 	}
 	AddCandidate(scan, so->n_layers-1, hc);
 }
@@ -729,7 +728,7 @@ GetCandidate(IndexScanDesc scan, int lc, int ef)
 		HnswCandidate* hc = ((HnswPairingHeapNode *) pairingheap_remove_first(layer->W))->inner;
 		layer->n -= lc != 0 || list_length(hc->element->heaptids) != 0;
 		if (pairingheap_is_empty(layer->W))
-			layer->max_distance = FLT_MAX;
+			layer->max_distance = 0;
 		return hc;
 	}
 }

--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -619,7 +619,7 @@ HnswInitScan(IndexScanDesc scan, Datum q)
 	for (i = 0; i < so->n_layers; i++)
 	{
 		so->layers[i].C = pairingheap_allocate(CompareNearestCandidates, NULL);
-		so->layers[i].W = pairingheap_allocate(CompareFurthestCandidates, NULL);
+		so->layers[i].W = pairingheap_allocate(CompareNearestCandidates, NULL);
 		so->layers[i].v = hash_create("hnsw visited", 256, &hash_ctl, HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 		so->layers[i].n = 0;
 	}

--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -577,7 +577,7 @@ AddCandidate(IndexScanDesc scan, int lc, HnswCandidate *hc)
 	{
 		pairingheap_add(layer->C, &(CreatePairingHeapNode(hc)->ph_node));
 		pairingheap_add(layer->W, &(CreatePairingHeapNode(hc)->ph_node));
-		layer->n += 1;
+		layer->n += lc != 0 || list_length(ec->element->heaptids) != 0;
 	}
 }
 

--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -692,7 +692,7 @@ GetCandidate(IndexScanDesc scan, int lc)
 {
 	HnswScanOpaque so = (HnswScanOpaque) scan->opaque;
 	LayerScanDesc* layer = &so->layers[lc];
-	while (pairingheap_is_empty(layer->W))
+	while (true)
 	{
 		if (!MoreCandidates(scan, lc))
 		{
@@ -705,13 +705,19 @@ GetCandidate(IndexScanDesc scan, int lc)
 					continue;
 				}
 			}
-			return NULL;
+			break;
 		}
 	}
-	Assert(layer->n > 0);
-	layer->n -= 1;
-	return ((HnswPairingHeapNode *) pairingheap_remove_first(layer->W))->inner;
-
+	if (pairingheap_is_empty(layer->W))
+	{
+		return NULL;
+	}
+	else
+	{
+		Assert(layer->n > 0);
+		layer->n -= 1;
+		return ((HnswPairingHeapNode *) pairingheap_remove_first(layer->W))->inner;
+	}
 }
 
 HnswCandidate*

--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -577,7 +577,7 @@ AddCandidate(IndexScanDesc scan, int lc, HnswCandidate *hc)
 	{
 		pairingheap_add(layer->C, &(CreatePairingHeapNode(hc)->ph_node));
 		pairingheap_add(layer->W, &(CreatePairingHeapNode(hc)->ph_node));
-		layer->n += lc != 0 || list_length(ec->element->heaptids) != 0;
+		layer->n += lc != 0 || list_length(hc->element->heaptids) != 0;
 	}
 }
 

--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -654,7 +654,7 @@ MoreCandidates(IndexScanDesc scan, int lc, int ef)
 	{
 		HnswNeighborArray *neighborhood;
 		HnswCandidate *c = ((HnswPairingHeapNode *) pairingheap_first(layer->C))->inner;
-		if (layer->n >= ef && c->distance > ((HnswPairingHeapNode*) pairingheap_nth(layer->W, ef))->inner->distance)
+		if (layer->n >= ef && c->distance > ((HnswPairingHeapNode*) pairingheap_nth(layer->W, ef - 1))->inner->distance)
 			return true;
 
 		pairingheap_remove_first(layer->C);

--- a/test/t/015_hnsw_duplicates.pl
+++ b/test/t/015_hnsw_duplicates.pl
@@ -28,7 +28,7 @@ sub test_duplicates
 		SET hnsw.ef_search = 1;
 		SELECT COUNT(*) FROM (SELECT * FROM tst ORDER BY v <-> '[1,1,1]') t;
 	));
-	is($res, 10);
+	is($res, 20);
 }
 
 # Test duplicates with build


### PR DESCRIPTION
See #259 for motivation of this PR.
In few words - if we wan to perform filtering after HNSW search, then `K=hnsw_ef_search` may be not enough to provide enough results to upper plan nodes.

Assume `hnsw_ef_seach=10`.
If we perform query:
```
select * from documents order by embedding<->array[...]::vector limit 10;
```
then it returns 10 result and it is ok.
If with the same `hnsw_ef_seach=10`. we execute query:
```
select * from documents order by embedding<->array[...]::vector limit 100;
```
and it still returns 10 results it is no so good. But at least here we can easily change`hnsw-ef-search` to 100 and get proper number of results.

But if we do 
```
select * from documents where category in (1,2,3) order by embedding<->array[...]::vector limit 10;
```
and it returns 0 results, then we do not know whether there are actually no documents belonging to this categories or them just too far from specified point. And it is not clear how to increase `hnsw_ef_search` to return proper number of results.

There are three possible solutions of the problem:
1. Push down filter condition to SearchKNN method and perform filtering before cutting K results. Unfortunately Postgres index AM doesn't allow to do it.
2. Repeat search with larger `ef_search`. This is what I have implemented in my previous PR: #266. This solution has two drawbacks:
 - double amount of works caused by query retry
 - not strict order of returns results
3. Implement iterator which  usable to return all elements in increasing distance order.

Approach 3 I tried to implement in this PR. It is similar with how KNN is implemented in Postgres for GIST indexes.
The main difference between GIST and HNSW is that first one is using wrapping rectangles which allows to cut traverse tree without sorting all elements. If we have wrapping rectangles A=[(ax1,ay1),(ax2,ay2)] and  B=[(bx1,by1),(bx2,by2)] and search for points closer to (x,y), then if x<ax1 and ax2<bx1 and y<ay1 and ay2<by1, then we can traverse first all siblings of A and then all siblings of B.

Unfortunately fir HNSW it doesn't work:  if we have two vectors V1, V2 and search vector V and `V1<->V < V2<->V` (distance between V1 and V is smaller than distance between V2 and V), then it doesn't mean that the same is true for all neighbours of V1 and V2. So unlike GIST we can not provide strict order, in other words we can return vector with larger distance prior to vector with smaller distance. But as far as our search is approximate in any case, it seems to be ok.

How HNSW search was implemented before? We recursively traverse vertexes at each layer, marking them as visible and rejecting candidates with distance large than already chosen. The search is repeated for each layer. For intermediate layers `ef=1` (which means that we choose only one candidate) and for leaf layer = `ef=hnsw_ef_search`. For each layer we use hash for marking listed vertexes and two pairing heaps: for maintaining sorted sets of candidates and results.

Iterator need to keep state of recursive traversal of all layers. So we create  stack (array) with number of elements equal to number of layers and each element contains hash and 2 pairing heaps. We can not reject elements with larger distance, because them have to be traversed I any case. We just put all of them in pairing heap. To prevent memory overflow we stop traversal if we have found enough results (1 for internal layer and `hnsw_ef_search` for leaf layer) and there are no more candidates at distance less or equal than distance to the n-th already chosen result.

Similar think was already implemented in TImescaleDB HNSW index implementation:
https://news.ycombinator.com/item?id=37648913

Also related links:
https://medium.com/pinterest-engineering/manas-hnsw-streaming-filters-351adf9ac1c4
https://towardsdatascience.com/effects-of-filtered-hnsw-searches-on-recall-and-latency-434becf8041c
 

