### PR TITLE
Speed up HNSW index build

### DIFF
--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -14,6 +14,13 @@
 #error "Requires PostgreSQL 11+"
 #endif
 
+/*
+ * If defined, you get a NOTICE message with # of distance calculations
+ * at the end of HNSW index build
+ */
+/* #define HNSW_DISTANCE_CALC_STATS */
+
+
 #define HNSW_MAX_DIM 2000
 
 /* Support functions */
@@ -301,5 +308,10 @@ IndexScanDesc hnswbeginscan(Relation index, int nkeys, int norderbys);
 void		hnswrescan(IndexScanDesc scan, ScanKey keys, int nkeys, ScanKey orderbys, int norderbys);
 bool		hnswgettuple(IndexScanDesc scan, ScanDirection dir);
 void		hnswendscan(IndexScanDesc scan);
+
+#ifdef HNSW_DISTANCE_CALC_STATS
+void HnswResetDistanceCalcStats(void);
+void HnswPrintDistanceCalcStats(void);
+#endif
 
 #endif

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -113,10 +113,16 @@ typedef struct HnswElementData
 
 typedef HnswElementData * HnswElement;
 
+/* values for HnswCandidate.neighborStatus */
+#define NS_UNKNOWN    0
+#define NS_SOLID      1
+#define NS_NONSOLID   2
+
 typedef struct HnswCandidate
 {
 	HnswElement element;
 	float		distance;
+	char		neighborStatus;
 }			HnswCandidate;
 
 typedef struct HnswNeighborArray

--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -481,6 +481,10 @@ static void
 BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo,
 		   HnswBuildState * buildstate, ForkNumber forkNum)
 {
+#ifdef HNSW_DISTANCE_CALC_STATS
+	HnswResetDistanceCalcStats();
+#endif
+
 	InitBuildState(buildstate, heap, index, indexInfo, forkNum);
 
 	if (buildstate->heap != NULL)
@@ -490,6 +494,10 @@ BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo,
 		FlushPages(buildstate);
 
 	FreeBuildState(buildstate);
+
+#ifdef HNSW_DISTANCE_CALC_STATS
+	HnswPrintDistanceCalcStats();
+#endif
 }
 
 /*


### PR DESCRIPTION
## Intro

I did some profiling and noticed that during HNSW index build, a lot of time is spent in the distance calculations when updating the neighbors. That's the SelectNeighbors function, or Algorithm 4 in the HNSW paper.

A lot of that work is repetitive. We build from scratch almost the same set of neighbors, even though we have merely added one candidate to the set, and only need to prune one old candidate. If we memorize a little bit more information about that work, we can do that incrementally and greatly reduce the number of distance calculations.

## Commits

This PR is split into three commits for easier review:

1. Add counters on the number of distance calculations. This doesn't change anything in the algorithm, but establishes a baseline. Not sure if we'd want to push this, but it was useful to measure during development.

2. For each neighbor, remember if it was kept merely to "fill up" the neighbors array, i.e. because of the keepPrunedConnections check in the HNSW paper. Use that flag to speed up the algorithm.

   This already gives a nice speedup, without changing the overall structure of the code much. That makes it pretty easy to review for correctness I hope.

   This increases memory usage somewhat, as we need an extra bit or two per neighbor connection. I didn't try to optimize that, but If we want to minimize memory usage, I'm sure we could pack those more tightly somehow.

3. Rewrite the function more thoroughly. It still implements the same algorithm, but avoids more work by taking more advantage of which neighbors were kept because of the keepPrunedConnections check.


Note that this does not change the resulting index in any way. The algorithm chooses the same neigbhors as current SelectNeighbors function, there's even an assertion for that in the 3rd patch. Although very occasionally, I've seen that warning fire, so there might be some small nondeterminism lurking that I've missed.

This is not quite ready to be merged, as the code could probably use some cleanup, and there's that one assertion warning that I haven't debugged yet. But I think this is a pretty promising speedup, with little downside.

## Benchmarks
To benchmark this, I've been using a subset of the 'angular-100' dataset from ann-benchmarks, on my laptop:

With first patch, to establish baseline with the counters:

```
postgres=# \timing
Timing is on.
postgres=# reindex index items_small_embedding_idx ;
NOTICE:  HNSW Distance calc stats: 15455422/3594194/771889185 (hit A, hit B, miss)
REINDEX
Time: 157050.024 ms (02:37.050)
```

With 2nd patch applied:

```
postgres=# \timing
Timing is on.
postgres=# reindex index items_small_embedding_idx ;
NOTICE:  HNSW Distance calc stats: 10332982/2256192/364683280 (hit A, hit B, miss)
REINDEX
Time: 123400.589 ms (02:03.401)
```

With all patches:

```
postgres=# \timing
Timing is on.
postgres=# reindex index items_small_embedding_idx ;
NOTICE:  HNSW Distance calc stats: 3959168/1032839/109604571 (hit A, hit B, miss)
REINDEX
Time: 103006.091 ms (01:43.006)
```

So this speeds up the build from 157 s to 103 s. 
