### PR TITLE
Provide estimate of total tuples to insert on bulk HNSW build

### DIFF
--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -20,6 +20,7 @@
 #include "access/tableam.h"
 #include "commands/progress.h"
 #else
+#define PROGRESS_CREATEIDX_TUPLES_TOTAL 0
 #define PROGRESS_CREATEIDX_TUPLES_DONE 0
 #endif
 
@@ -464,6 +465,8 @@ static void
 BuildGraph(HnswBuildState * buildstate, ForkNumber forkNum)
 {
 	UpdateProgress(PROGRESS_CREATEIDX_SUBPHASE, PROGRESS_HNSW_PHASE_LOAD);
+	/* provide estimate of total number of tuples that will be indexed */
+	UpdateProgress(PROGRESS_CREATEIDX_TUPLES_TOTAL, buildstate->heap->rd_rel->reltuples);
 
 #if PG_VERSION_NUM >= 120000
 	buildstate->reltuples = table_index_build_scan(buildstate->heap, buildstate->index, buildstate->indexInfo,


### PR DESCRIPTION
We won't know how many tuples will actually be inserted until we finish the full table scan, but we can estimate the total based on the value avaulable in `pg_class.reltuples`. This allows for the index creator to get an approximate estimate of how long a build may take.

Note that this leaves the default value of `-1` for reltuples in place if there is no data available.

fixes #320 