### PR TITLE
Add docker publish workflow

### DIFF
--- a/.github/workflows/release_docker_image.yml
+++ b/.github/workflows/release_docker_image.yml
@@ -17,13 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - postgres-major: 11
         - postgres-major: 12
         - postgres-major: 13
         - postgres-major: 14
         - postgres-major: 15
         - postgres-major: 16
-        - postgres-major: 17
     runs-on: ubuntu-latest
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:

--- a/.github/workflows/release_docker_image.yml
+++ b/.github/workflows/release_docker_image.yml
@@ -1,0 +1,52 @@
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['master']
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - postgres-major: 11
+        - postgres-major: 12
+        - postgres-major: 13
+        - postgres-major: 14
+        - postgres-major: 15
+        - postgres-major: 16
+        - postgres-major: 17
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          build-args: PG_MAJOR=${{matrix.postgres-major}}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.postgres-major }}


### PR DESCRIPTION
This adds a Github Workflow to build and publish a Docker image after every push to master. The images would be available as `ghcr.io/pgvector/pgvector:XX`, where XX is the Postgres major version. 

If you think this is a good idea, we should probably also adapt the Readme and point to these images instead.

I did not include Postgres versions 11 and 17, because building didn't work on 11, and there is no `postgres` Docker image for 17 yet.