### PR TITLE
Fix coredump about HnswFreeElement()

### DIFF
--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -177,6 +177,8 @@ HnswInitElement(ItemPointer heaptid, int m, double ml, int maxLevel)
 
 	HnswInitNeighbors(element, m);
 
+	element->value = PointerGetDatum(NULL);
+
 	return element;
 }
 


### PR DESCRIPTION
The HnswInitElement() allocate an element with not initialize value filed, which may has garbage that lead HnswFreeElement() free an invalid pointer.