### PR TITLE
Allow specify dimensions in CREATE INDEX

### DIFF
--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -37,6 +37,10 @@ HnswInit(void)
 #endif
 		);
 
+	add_int_reloption(hnsw_relopt_kind, "dims", "Expected number of vector dimensions",
+					  -1, -1, HNSW_MAX_DIM
+					  ,AccessExclusiveLock
+		);
 	DefineCustomIntVariable("hnsw.ef_search", "Sets the size of the dynamic candidate list for search",
 							"Valid range is 1..1000.", &hnsw_ef_search,
 							HNSW_DEFAULT_EF_SEARCH, HNSW_MIN_EF_SEARCH, HNSW_MAX_EF_SEARCH, PGC_USERSET, 0, NULL, NULL, NULL);
@@ -97,7 +101,7 @@ hnswcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 	MemSet(&costs, 0, sizeof(costs));
 
 	index = index_open(path->indexinfo->indexoid, NoLock);
-	HnswGetMetaPageInfo(index, &m, NULL);
+	HnswGetMetaPageInfo(index, &m, NULL, NULL);
 	index_close(index, NoLock);
 
 	/* Approximate entry level */
@@ -131,6 +135,7 @@ hnswoptions(Datum reloptions, bool validate)
 	static const relopt_parse_elt tab[] = {
 		{"m", RELOPT_TYPE_INT, offsetof(HnswOptions, m)},
 		{"ef_construction", RELOPT_TYPE_INT, offsetof(HnswOptions, efConstruction)},
+		{"dims", RELOPT_TYPE_INT, offsetof(HnswOptions, dims)},
 	};
 
 #if PG_VERSION_NUM >= 130000

--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -39,7 +39,9 @@ HnswInit(void)
 
 	add_int_reloption(hnsw_relopt_kind, "dims", "Expected number of vector dimensions",
 					  -1, -1, HNSW_MAX_DIM
+#if PG_VERSION_NUM >= 130000
 					  ,AccessExclusiveLock
+#endif
 		);
 	DefineCustomIntVariable("hnsw.ef_search", "Sets the size of the dynamic candidate list for search",
 							"Valid range is 1..1000.", &hnsw_ef_search,

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -140,6 +140,7 @@ typedef struct HnswOptions
 	int32		vl_len_;		/* varlena header (do not touch directly!) */
 	int			m;				/* number of connections */
 	int			efConstruction; /* size of dynamic candidate list */
+	int 		dims;	/* dimensions of each vector datum */
 }			HnswOptions;
 
 typedef struct HnswSpool
@@ -324,7 +325,7 @@ void		HnswInitRegisterPage(Relation index, Buffer *buf, Page *page, GenericXLogS
 void		HnswInit(void);
 List	   *HnswSearchLayer(Datum q, List *ep, int ef, int lc, Relation index, FmgrInfo *procinfo, Oid collation, int m, bool inserting, HnswElement skipElement);
 HnswElement HnswGetEntryPoint(Relation index);
-void		HnswGetMetaPageInfo(Relation index, int *m, HnswElement * entryPoint);
+void		HnswGetMetaPageInfo(Relation index, int *m, int *dims, HnswElement *entryPoint);
 HnswElement HnswInitElement(ItemPointer tid, int m, double ml, int maxLevel);
 void		HnswFreeElement(HnswElement element);
 HnswElement HnswInitElementFromBlock(BlockNumber blkno, OffsetNumber offno);
@@ -359,5 +360,6 @@ IndexScanDesc hnswbeginscan(Relation index, int nkeys, int norderbys);
 void		hnswrescan(IndexScanDesc scan, ScanKey keys, int nkeys, ScanKey orderbys, int norderbys);
 bool		hnswgettuple(IndexScanDesc scan, ScanDirection dir);
 void		hnswendscan(IndexScanDesc scan);
+int 		HnswGetBuildStateDims(Relation index);
 
 #endif

--- a/src/hnswscan.c
+++ b/src/hnswscan.c
@@ -23,7 +23,7 @@ GetScanItems(IndexScanDesc scan, Datum q)
 	HnswElement entryPoint;
 
 	/* Get m and entry point */
-	HnswGetMetaPageInfo(index, &m, &entryPoint);
+	HnswGetMetaPageInfo(index, &m, NULL, &entryPoint);
 
 	if (entryPoint == NULL)
 		return NIL;

--- a/src/hnswvacuum.c
+++ b/src/hnswvacuum.c
@@ -594,7 +594,7 @@ InitVacuumState(HnswVacuumState * vacuumstate, IndexVacuumInfo *info, IndexBulkD
 												ALLOCSET_DEFAULT_SIZES);
 
 	/* Get m from metapage */
-	HnswGetMetaPageInfo(index, &vacuumstate->m, NULL);
+	HnswGetMetaPageInfo(index, &vacuumstate->m, NULL, NULL);
 
 	/* Create hash table */
 	hash_ctl.keysize = sizeof(ItemPointerData);

--- a/src/ivfbuild.c
+++ b/src/ivfbuild.c
@@ -174,6 +174,8 @@ AddTupleToSort(Relation index, ItemPointer tid, Datum *values, IvfflatBuildState
 
 	/* Detoast once for all calls */
 	Datum		value = PointerGetDatum(PG_DETOAST_DATUM(values[0]));
+	Vector *	vec = DatumGetVector(value);
+	CheckExpectedDim(buildstate->dimensions, vec->dim);
 
 	/* Normalize if needed */
 	if (buildstate->normprocinfo != NULL)
@@ -352,15 +354,7 @@ InitBuildState(IvfflatBuildState * buildstate, Relation heap, Relation index, In
 	buildstate->indexInfo = indexInfo;
 
 	buildstate->lists = IvfflatGetLists(index);
-	buildstate->dimensions = TupleDescAttr(index->rd_att, 0)->atttypmod;
-
-	/* Require column to have dimensions to be indexed */
-	if (buildstate->dimensions < 0)
-		elog(ERROR, "column does not have dimensions");
-
-	if (buildstate->dimensions > IVFFLAT_MAX_DIM)
-		elog(ERROR, "column cannot have more than %d dimensions for ivfflat index", IVFFLAT_MAX_DIM);
-
+	buildstate->dimensions = IvfflatGetBuildStateDims(index);
 	buildstate->reltuples = 0;
 	buildstate->indtuples = 0;
 

--- a/src/ivfflat.c
+++ b/src/ivfflat.c
@@ -31,7 +31,9 @@ IvfflatInit(void)
 		);
 	add_int_reloption(ivfflat_relopt_kind, "dims", "Expected number of vector dimensions",
 					  -1, -1, IVFFLAT_MAX_DIM
+#if PG_VERSION_NUM >= 130000
 					  ,AccessExclusiveLock
+#endif
 		);
 
 	DefineCustomIntVariable("ivfflat.probes", "Sets the number of probes",

--- a/src/ivfflat.c
+++ b/src/ivfflat.c
@@ -29,6 +29,10 @@ IvfflatInit(void)
 					  ,AccessExclusiveLock
 #endif
 		);
+	add_int_reloption(ivfflat_relopt_kind, "dims", "Expected number of vector dimensions",
+					  -1, -1, IVFFLAT_MAX_DIM
+					  ,AccessExclusiveLock
+		);
 
 	DefineCustomIntVariable("ivfflat.probes", "Sets the number of probes",
 							"Valid range is 1..lists.", &ivfflat_probes,
@@ -152,6 +156,7 @@ ivfflatoptions(Datum reloptions, bool validate)
 {
 	static const relopt_parse_elt tab[] = {
 		{"lists", RELOPT_TYPE_INT, offsetof(IvfflatOptions, lists)},
+		{"dims", RELOPT_TYPE_INT, offsetof(IvfflatOptions, dims)},
 	};
 
 #if PG_VERSION_NUM >= 130000

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -104,6 +104,7 @@ typedef struct IvfflatOptions
 {
 	int32		vl_len_;		/* varlena header (do not touch directly!) */
 	int			lists;			/* number of lists */
+	int			dims;			/* dimensions of each vector datum */
 }			IvfflatOptions;
 
 typedef struct IvfflatSpool
@@ -303,5 +304,6 @@ IndexScanDesc ivfflatbeginscan(Relation index, int nkeys, int norderbys);
 void		ivfflatrescan(IndexScanDesc scan, ScanKey keys, int nkeys, ScanKey orderbys, int norderbys);
 bool		ivfflatgettuple(IndexScanDesc scan, ScanDirection dir);
 void		ivfflatendscan(IndexScanDesc scan);
+int		IvfflatGetBuildStateDims(Relation index);
 
 #endif

--- a/src/ivfinsert.c
+++ b/src/ivfinsert.c
@@ -76,9 +76,16 @@ InsertTuple(Relation index, Datum *values, bool *isnull, ItemPointer heap_tid, R
 	BlockNumber insertPage = InvalidBlockNumber;
 	ListInfo	listInfo;
 	BlockNumber originalInsertPage;
+	Vector		*vec;
+	int 		dims;
 
 	/* Detoast once for all calls */
 	value = PointerGetDatum(PG_DETOAST_DATUM(values[0]));
+	vec = DatumGetVector(value);
+
+	/* check dim */
+	IvfflatGetMetaPageInfo(index, NULL, &dims);
+	CheckExpectedDim(dims, vec->dim);
 
 	/* Normalize if needed */
 	normprocinfo = IvfflatOptionalProcInfo(index, IVFFLAT_NORM_PROC);

--- a/src/vector.c
+++ b/src/vector.c
@@ -60,18 +60,6 @@ CheckDims(Vector * a, Vector * b)
 }
 
 /*
- * Ensure expected dimensions
- */
-static inline void
-CheckExpectedDim(int32 typmod, int dim)
-{
-	if (typmod != -1 && typmod != dim)
-		ereport(ERROR,
-				(errcode(ERRCODE_DATA_EXCEPTION),
-				 errmsg("expected %d dimensions, not %d", typmod, dim)));
-}
-
-/*
  * Ensure valid dimensions
  */
 static inline void

--- a/src/vector.h
+++ b/src/vector.h
@@ -20,4 +20,15 @@ Vector	   *InitVector(int dim);
 void		PrintVector(char *msg, Vector * vector);
 int			vector_cmp_internal(Vector * a, Vector * b);
 
+/*
+ * Ensure expected dimensions
+ */
+static inline void
+CheckExpectedDim(int32 expectedDim, int dim)
+{
+	if (expectedDim != -1 && expectedDim != dim)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATA_EXCEPTION),
+				 errmsg("expected %d dimensions, not %d", expectedDim, dim)));
+}
 #endif

--- a/test/expected/hnsw_dim.out
+++ b/test/expected/hnsw_dim.out
@@ -1,0 +1,24 @@
+SET enable_seqscan = off;
+CREATE TABLE t (val vector);
+INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
+CREATE INDEX t_val_1 ON t USING hnsw (val vector_cosine_ops) WITH (dims = 3);
+INSERT INTO t (val) VALUES ('[1,2,4]');
+INSERT INTO t (val) VALUES ('[1,2,4,5]');
+ERROR:  expected 3 dimensions, not 4
+SELECT * FROM t ORDER BY val <=> '[3,3,3]';
+   val   
+---------
+ [1,1,1]
+ [1,2,3]
+ [1,2,4]
+(3 rows)
+
+INSERT INTO t (val) VALUES ('[1,2,4,5]');
+ERROR:  expected 3 dimensions, not 4
+CREATE INDEX t_val_2 ON t USING hnsw(val vector_cosine_ops) WITH (dims = 4);
+ERROR:  expected 4 dimensions, not 3
+TRUNCATE t;
+CREATE INDEX t_val_3 ON t USING hnsw(val vector_cosine_ops) WITH (dims = 4);
+INSERT INTO t (val) VALUES ('[1,2,4]');
+ERROR:  expected 4 dimensions, not 3
+DROP TABLE t;

--- a/test/expected/ivfflat_dim.out
+++ b/test/expected/ivfflat_dim.out
@@ -1,0 +1,30 @@
+SET enable_seqscan = off;
+CREATE TABLE t (val vector);
+INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
+CREATE INDEX t_val_1 ON t USING ivfflat (val vector_cosine_ops) WITH (lists = 1, dims = 3);
+INSERT INTO t (val) VALUES ('[1,2,4]');
+INSERT INTO t (val) VALUES ('[1,2,4,5]');
+ERROR:  expected 3 dimensions, not 4
+SELECT * FROM t ORDER BY val <=> '[3,3,3]';
+   val   
+---------
+ [1,1,1]
+ [1,2,3]
+ [1,2,4]
+(3 rows)
+
+INSERT INTO t (val) VALUES ('[1,2,4,5]');
+ERROR:  expected 3 dimensions, not 4
+CREATE INDEX t_val_2 ON t USING ivfflat (val vector_cosine_ops) WITH (lists = 1, dims = 4);
+ERROR:  expected 4 dimensions, not 3
+TRUNCATE t;
+NOTICE:  ivfflat index created with little data
+DETAIL:  This will cause low recall.
+HINT:  Drop the index until the table has more data.
+CREATE INDEX t_val_3 ON t USING ivfflat (val vector_cosine_ops) WITH (lists = 1, dims = 4);
+NOTICE:  ivfflat index created with little data
+DETAIL:  This will cause low recall.
+HINT:  Drop the index until the table has more data.
+INSERT INTO t (val) VALUES ('[1,2,4]');
+ERROR:  expected 4 dimensions, not 3
+DROP TABLE t;

--- a/test/sql/hnsw_dim.sql
+++ b/test/sql/hnsw_dim.sql
@@ -1,0 +1,19 @@
+SET enable_seqscan = off;
+
+CREATE TABLE t (val vector);
+INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
+CREATE INDEX t_val_1 ON t USING hnsw (val vector_cosine_ops) WITH (dims = 3);
+
+INSERT INTO t (val) VALUES ('[1,2,4]');
+INSERT INTO t (val) VALUES ('[1,2,4,5]');
+
+SELECT * FROM t ORDER BY val <=> '[3,3,3]';
+
+INSERT INTO t (val) VALUES ('[1,2,4,5]');
+CREATE INDEX t_val_2 ON t USING hnsw(val vector_cosine_ops) WITH (dims = 4);
+
+TRUNCATE t;
+CREATE INDEX t_val_3 ON t USING hnsw(val vector_cosine_ops) WITH (dims = 4);
+INSERT INTO t (val) VALUES ('[1,2,4]');
+
+DROP TABLE t;

--- a/test/sql/ivfflat_dim.sql
+++ b/test/sql/ivfflat_dim.sql
@@ -1,0 +1,19 @@
+SET enable_seqscan = off;
+
+CREATE TABLE t (val vector);
+INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
+CREATE INDEX t_val_1 ON t USING ivfflat (val vector_cosine_ops) WITH (lists = 1, dims = 3);
+
+INSERT INTO t (val) VALUES ('[1,2,4]');
+INSERT INTO t (val) VALUES ('[1,2,4,5]');
+
+SELECT * FROM t ORDER BY val <=> '[3,3,3]';
+
+INSERT INTO t (val) VALUES ('[1,2,4,5]');
+CREATE INDEX t_val_2 ON t USING ivfflat (val vector_cosine_ops) WITH (lists = 1, dims = 4);
+
+TRUNCATE t;
+CREATE INDEX t_val_3 ON t USING ivfflat (val vector_cosine_ops) WITH (lists = 1, dims = 4);
+INSERT INTO t (val) VALUES ('[1,2,4]');
+
+DROP TABLE t;


### PR DESCRIPTION
As the typmod of vector can be -1, which means that we can create a table and insert data into it without caring the dimension. For ivfflat and hnsw index, they both need the dimension, so I think we can set the dimension when creating index.

In some cases, dimensions of vector cannot be determined prior to seeing the vector. For example, the vectors might be generated by a complex UDF. Such UDFs are possibly developed by data scientists and the details might be hard to comprehend for the user calling them.

This means users who want to load the generated vectors and do the search when developing the application will not be able to specify the dimensions of the vectors before the vectors are written to the table and the type of the column will only be vector instead of vector(<dims>). As a result, when creating index, there will be an error like

ERROR:  column does not have dimensions
To mitigate this issue, this patch adds an option dims to the access methods, allowing the user to specify the dimensions after seeing the vectors in the table. In this way, the user does not need to care about how the vectors are generated in order to search them.