### PR TITLE
Use LockBuffer instead of LockBufferForCleanup when doing bulkdelete

### DIFF
--- a/src/hnswvacuum.c
+++ b/src/hnswvacuum.c
@@ -463,13 +463,7 @@ MarkDeleted(HnswVacuumState * vacuumstate)
 
 		buf = ReadBufferExtended(index, MAIN_FORKNUM, blkno, RBM_NORMAL, bas);
 
-		/*
-		 * ambulkdelete cannot delete entries from pages that are pinned by
-		 * other backends
-		 *
-		 * https://www.postgresql.org/docs/current/index-locking.html
-		 */
-		LockBufferForCleanup(buf);
+		LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
 
 		state = GenericXLogStart(index);
 		page = GenericXLogRegisterBuffer(state, buf, 0);

--- a/src/ivfvacuum.c
+++ b/src/ivfvacuum.c
@@ -67,13 +67,7 @@ ivfflatbulkdelete(IndexVacuumInfo *info, IndexBulkDeleteResult *stats,
 
 				buf = ReadBufferExtended(index, MAIN_FORKNUM, searchPage, RBM_NORMAL, bas);
 
-				/*
-				 * ambulkdelete cannot delete entries from pages that are
-				 * pinned by other backends
-				 *
-				 * https://www.postgresql.org/docs/current/index-locking.html
-				 */
-				LockBufferForCleanup(buf);
+				LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
 
 				state = GenericXLogStart(index);
 				page = GenericXLogRegisterBuffer(state, buf, 0);


### PR DESCRIPTION
As both ivfflat and hnsw don't support non-mvcc snapshot, so there is no need to call LockBufferForCleanup when doing bulkdelete.