### PR TITLE
l2_distance (instead of vector_l2_squared_distance) getting called while creating index

### DIFF
--- a/src/ivfkmeans.c
+++ b/src/ivfkmeans.c
@@ -21,7 +21,7 @@ InitCenters(Relation index, VectorArray samples, VectorArray centers, float *low
 	int			numCenters = centers->maxlen;
 	int			numSamples = samples->length;
 
-	procinfo = index_getprocinfo(index, 1, IVFFLAT_KMEANS_DISTANCE_PROC);
+	procinfo = index_getprocinfo(index, 1, IVFFLAT_DISTANCE_PROC);
 	collation = index->rd_indcollation[0];
 
 	/* Choose an initial center uniformly at random */
@@ -209,7 +209,7 @@ ElkanKmeans(Relation index, VectorArray samples, VectorArray centers)
 		elog(ERROR, "Indexing overflow detected. Please report a bug.");
 
 	/* Set support functions */
-	procinfo = index_getprocinfo(index, 1, IVFFLAT_KMEANS_DISTANCE_PROC);
+	procinfo = index_getprocinfo(index, 1, IVFFLAT_DISTANCE_PROC);
 	normprocinfo = IvfflatOptionalProcInfo(index, IVFFLAT_KMEANS_NORM_PROC);
 	collation = index->rd_indcollation[0];
 


### PR DESCRIPTION
While computing the centers (`ComputeCenters`) `IVFFLAT_KMEANS_DISTANCE_PROC` is being used instead of `IVFFLAT_DISTANCE_PROC`. This causes the call to l2_distance instead of vector_l2_squared_distance. 

To reproduce the problem: https://gist.github.com/ankane/2ea49423534051eb76565435e76b4b83 