### PR TITLE
Replace dynahash hash table in HNSW with simplehash, for speed

### DIFF
--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -303,7 +303,7 @@ typedef struct HnswVacuumState
 	Oid			collation;
 
 	/* Variables */
-	HTAB	   *deleted;
+	struct tids_hash *deleted;
 	BufferAccessStrategy bas;
 	HnswNeighborTuple ntup;
 	HnswElementData highestPoint;
@@ -359,5 +359,34 @@ IndexScanDesc hnswbeginscan(Relation index, int nkeys, int norderbys);
 void		hnswrescan(IndexScanDesc scan, ScanKey keys, int nkeys, ScanKey orderbys, int norderbys);
 bool		hnswgettuple(IndexScanDesc scan, ScanDirection dir);
 void		hnswendscan(IndexScanDesc scan);
+
+/*
+ * TIDs and pointers hash table declarations. These are defined in
+ * hnswutils.c.
+ */
+
+typedef struct {
+	ItemPointerData tid;
+	char		status;
+} TidHashEntry;
+
+#define SH_PREFIX tids
+#define SH_ELEMENT_TYPE TidHashEntry
+#define SH_KEY_TYPE ItemPointerData
+#define SH_SCOPE extern
+#define SH_DECLARE
+#include "lib/simplehash.h"
+
+typedef struct {
+	uintptr_t	ptr;
+	char		status;
+} PointerHashEntry;
+
+#define SH_PREFIX pointers
+#define SH_ELEMENT_TYPE PointerHashEntry
+#define SH_KEY_TYPE uintptr_t
+#define SH_SCOPE extern
+#define SH_DECLARE
+#include "lib/simplehash.h"
 
 #endif

--- a/src/hnswvacuum.c
+++ b/src/hnswvacuum.c
@@ -12,12 +12,9 @@
  * Check if deleted list contains an index TID
  */
 static bool
-DeletedContains(HTAB *deleted, ItemPointer indextid)
+DeletedContains(tids_hash *deleted, ItemPointer indextid)
 {
-	bool		found;
-
-	hash_search(deleted, indextid, HASH_FIND, &found);
-	return found;
+	return tids_lookup(deleted, *indextid) != NULL;
 }
 
 /*
@@ -110,11 +107,13 @@ RemoveHeapTids(HnswVacuumState * vacuumstate)
 			if (!ItemPointerIsValid(&etup->heaptids[0]))
 			{
 				ItemPointerData ip;
+				bool		found;
 
 				/* Add to deleted list */
 				ItemPointerSet(&ip, blkno, offno);
 
-				(void) hash_search(vacuumstate->deleted, &ip, HASH_ENTER, NULL);
+				tids_insert(vacuumstate->deleted, ip, &found);
+				Assert(!found);
 			}
 			else if (etup->level > highestLevel && !(entryPoint != NULL && blkno == entryPoint->blkno && offno == entryPoint->offno))
 			{
@@ -575,7 +574,6 @@ static void
 InitVacuumState(HnswVacuumState * vacuumstate, IndexVacuumInfo *info, IndexBulkDeleteResult *stats, IndexBulkDeleteCallback callback, void *callback_state)
 {
 	Relation	index = info->index;
-	HASHCTL		hash_ctl;
 
 	if (stats == NULL)
 		stats = (IndexBulkDeleteResult *) palloc0(sizeof(IndexBulkDeleteResult));
@@ -597,10 +595,7 @@ InitVacuumState(HnswVacuumState * vacuumstate, IndexVacuumInfo *info, IndexBulkD
 	HnswGetMetaPageInfo(index, &vacuumstate->m, NULL);
 
 	/* Create hash table */
-	hash_ctl.keysize = sizeof(ItemPointerData);
-	hash_ctl.entrysize = sizeof(ItemPointerData);
-	hash_ctl.hcxt = CurrentMemoryContext;
-	vacuumstate->deleted = hash_create("hnswbulkdelete indextids", 256, &hash_ctl, HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+	vacuumstate->deleted = tids_create(CurrentMemoryContext, 256, NULL);
 }
 
 /*
@@ -609,7 +604,7 @@ InitVacuumState(HnswVacuumState * vacuumstate, IndexVacuumInfo *info, IndexBulkD
 static void
 FreeVacuumState(HnswVacuumState * vacuumstate)
 {
-	hash_destroy(vacuumstate->deleted);
+	tids_destroy(vacuumstate->deleted);
 	FreeAccessStrategy(vacuumstate->bas);
 	pfree(vacuumstate->ntup);
 	MemoryContextDelete(vacuumstate->tmpCtx);


### PR DESCRIPTION
This speeds up HNSW index build by about 10% in some quick tests on my laptop. Should never be slower. Searches benefit too, especially with high ef_search settings.

For the sake of consistency, I also changed VACUUM to use it, but I don't think it's performance critical there.

(I did this a while ago already but got distracted and forgot about it before submitting a PR. I remembered it now)

## Benchmark

I used a subset of the glove-100-angular dataset from ann-benchmarks (I think that's what this was anyway; I extracted this test data a while ago and didn't keep notes):

```
postgres=# \d items_small
                Table "public.items_small"
  Column   |    Type     | Collation | Nullable | Default 
-----------+-------------+-----------+----------+---------
 id        | integer     |           |          | 
 embedding | vector(100) |           |          | 
Indexes:
    "items_small_embedding_idx" hnsw (embedding vector_cosine_ops) WITH (m='16', ef_construction='200')

postgres=# select count(*) from items_small;
 count 
-------
 50000
(1 row)
```

On master:
```
postgres=# \timing
Timing is on.
postgres=# reindex index items_small_embedding_idx ;
REINDEX
Time: 80313.248 ms (01:20.313)
postgres=# reindex index items_small_embedding_idx ;
REINDEX
Time: 72729.057 ms (01:12.729)
postgres=# reindex index items_small_embedding_idx ;
REINDEX
Time: 71265.495 ms (01:11.265)
postgres=# 
```

With this PR:
```
postgres=# \timing
Timing is on.
postgres=# reindex index items_small_embedding_idx ;
REINDEX
Time: 70778.870 ms (01:10.779)
postgres=# reindex index items_small_embedding_idx ;
REINDEX
Time: 64770.006 ms (01:04.770)
postgres=# reindex index items_small_embedding_idx ;
REINDEX
Time: 62349.657 ms (01:02.350)
```

Not a very rigorous test, but shows that this helps. I'm pretty confident this will never lose over dynahash, even if it might not make a difference with other workloads. The simplehash implementation and the murmurhash function I used here are simply better.