### PR TITLE
Use separate memory context for in-memory graph, and some InsertTuple refactoring

### DIFF
--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -218,7 +218,8 @@ typedef struct HnswBuildState
 	Vector	   *normvec;
 
 	/* Memory */
-	MemoryContext tmpCtx;
+	MemoryContext memGraphCtx;		/* holds the graph during in-memory build */
+	MemoryContext tmpCtx;			/* reset between each tuple */
 
 	/* Parallel builds */
 	HnswLeader *hnswleader;

--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -271,6 +271,9 @@ CreateNeighborPages(HnswBuildState * buildstate)
 static void
 FlushPages(HnswBuildState * buildstate)
 {
+	elog(LOG, "memoryUsed: %lu", maintenance_work_mem * 1024L - buildstate->memoryLeft);
+	MemoryContextStats(buildstate->memGraphCtx);
+
 	CreateMetaPage(buildstate);
 	CreateElementPages(buildstate);
 	CreateNeighborPages(buildstate);


### PR DESCRIPTION
The first commit adds a new 'memGraphCtx' memory context, to hold the in-memory graph during HNSW index build. That makes it more convenient to drop it in toto, when we run out of maintenance_work_mem and switch to the on-disk method. But more importantly, it adds better visibility to the memory usage, when all the long-lived stuff that's supposed to be covered by maintenance_work_mem is allocated in a separate context.

The second commit does some refactoring in around the InsertTuple function and its caller. I found the naming confusing, so I renamed InsertTuple to InsertTupleInMemory to make it clear that it's only used in the in-memory phase. And I moved more code from the caller to inside the function, which I think it makes the codepath together more readable.

The third commit is not intended to be merged, but I'm including it here to show how the first patch is useful. It adds some log lines to the end of HNSW index build, to show the amount of memory allocated according to the 'memoryLeft' variable that we use to decide when we need to switch to on-disk build, and the actual memory usage according to the memory context's accounting. That allows you to compare them easily. And it shows that we have a pretty wide gap, ie. the HNSW index build can overshoot maintenance_work mem pretty significantly. Here's one example:

```
2023-12-19 23:50:26.224 EET [335097] LOG:  memoryUsed: 50419632
2023-12-19 23:50:26.224 EET [335097] STATEMENT:  reindex index items_small_embedding_idx;
Hnsw in-memory build context: 67633200 total in 19 blocks; 4958072 free (12 chunks); 62675128 used
Grand total: 67633200 bytes in 19 blocks; 4958072 free (12 chunks); 62675128 used
```

Comparing 'memoryUsed' and the "used" value at the end, the memory usage overshoot our accounting by about 24% (62675128 / 50419632).