### PR TITLE
Optimize memory usage

### DIFF
--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -218,7 +218,8 @@ typedef struct HnswBuildState
 	Vector	   *normvec;
 
 	/* Memory */
-	MemoryContext tmpCtx;
+	MemoryContext memGraphCtx;		/* holds the graph during in-memory build */
+	MemoryContext tmpCtx;			/* reset between each tuple */
 
 	/* Parallel builds */
 	HnswLeader *hnswleader;

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -102,14 +102,15 @@ typedef struct HnswNeighborArray HnswNeighborArray;
 typedef struct HnswElementData
 {
 	List	   *heaptids;
-	uint8		level;
-	uint8		deleted;
-	uint32		hash;
-	HnswNeighborArray *neighbors;
 	BlockNumber blkno;
 	OffsetNumber offno;
 	OffsetNumber neighborOffno;
 	BlockNumber neighborPage;
+
+	uint8		level;
+	uint8		deleted;
+	uint32		hash;
+	HnswNeighborArray *neighbors;
 	Datum		value;
 }			HnswElementData;
 
@@ -327,7 +328,7 @@ void		HnswInit(void);
 List	   *HnswSearchLayer(Datum q, List *ep, int ef, int lc, Relation index, FmgrInfo *procinfo, Oid collation, int m, bool inserting, HnswElement skipElement);
 HnswElement HnswGetEntryPoint(Relation index);
 void		HnswGetMetaPageInfo(Relation index, int *m, HnswElement * entryPoint);
-HnswElement HnswInitElement(ItemPointer tid, int m, double ml, int maxLevel);
+HnswElement HnswInitElement(ItemPointer tid, int m, double ml, int maxLevel, Datum value);
 void		HnswFreeElement(HnswElement element);
 HnswElement HnswInitElementFromBlock(BlockNumber blkno, OffsetNumber offno);
 void		HnswInsertElement(HnswElement element, HnswElement entryPoint, Relation index, FmgrInfo *procinfo, Oid collation, int m, int efConstruction, bool existing);

--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -317,11 +317,10 @@ InsertTupleInMemory(Relation index, ItemPointer heaptid, Datum *values, HnswBuil
 
 	/* Allocate element in the long-lived memory context */
 	MemoryContextSwitchTo(buildstate->memGraphCtx);
-	element = HnswInitElement(heaptid, buildstate->m, buildstate->ml, buildstate->maxLevel);
-	element->value = datumCopy(value, false, -1);
+	element = HnswInitElement(heaptid, buildstate->m, buildstate->ml, buildstate->maxLevel, value);
 	MemoryContextSwitchTo(buildstate->tmpCtx);
 
-	/* Insert element in graph */
+	/* Find insert location in graph. In other words, fill in the neighbors arrays in 'element' */
 	HnswInsertElement(element, entryPoint, NULL, procinfo, collation, m, efConstruction, false);
 
 	/* Look for duplicate */

--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -271,6 +271,9 @@ CreateNeighborPages(HnswBuildState * buildstate)
 static void
 FlushPages(HnswBuildState * buildstate)
 {
+	elog(LOG, "memoryUsed: %lu", maintenance_work_mem * 1024L - buildstate->memoryLeft);
+	MemoryContextStats(buildstate->memGraphCtx);
+
 	CreateMetaPage(buildstate);
 	CreateElementPages(buildstate);
 	CreateNeighborPages(buildstate);

--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -370,8 +370,14 @@ HnswElementMemory(HnswElement e, int m)
 
 	elementSize += sizeof(HnswNeighborArray) * (e->level + 1);
 	elementSize += sizeof(HnswCandidate) * (m * (e->level + 2));
-	elementSize += sizeof(ItemPointerData);
 	elementSize += VARSIZE_ANY(DatumGetPointer(e->value));
+
+	/*
+	 * Account for palloc overhead. (XXX: This is just a rough estimate, and
+	 * we know it's too small.).
+	 */
+	elementSize += 6;
+
 	return elementSize;
 }
 

--- a/src/hnswinsert.c
+++ b/src/hnswinsert.c
@@ -516,7 +516,7 @@ HnswInsertTuple(Relation index, Datum *values, bool *isnull, ItemPointer heap_ti
 	HnswGetMetaPageInfo(index, &m, &entryPoint);
 
 	/* Create an element */
-	element = HnswInitElement(heap_tid, m, HnswGetMl(m), HnswGetMaxLevel(m));
+	element = HnswInitElement(heap_tid, m, HnswGetMl(m), HnswGetMaxLevel(m), (Datum) 0);
 	element->value = value;
 
 	/* Prevent concurrent inserts when likely updating entry point */

--- a/src/hnswinsert.c
+++ b/src/hnswinsert.c
@@ -434,7 +434,7 @@ HnswAddDuplicate(Relation index, HnswElement element, HnswElement dup)
 	}
 
 	/* Add heap TID */
-	etup->heaptids[i] = *((ItemPointer) linitial(element->heaptids));
+	etup->heaptids[i] = HnswGetHeapTids(element)[0];
 
 	/* Overwrite tuple */
 	if (!PageIndexTupleOverwrite(page, dup->offno, (Item) etup, etupSize))

--- a/src/hnswscan.c
+++ b/src/hnswscan.c
@@ -185,25 +185,23 @@ hnswgettuple(IndexScanDesc scan, ScanDirection dir)
 	while (list_length(so->w) > 0)
 	{
 		HnswCandidate *hc = llast(so->w);
-		ItemPointer heaptid;
+		ItemPointerData heaptid;
 
 		/* Move to next element if no valid heap TIDs */
-		if (list_length(hc->element->heaptids) == 0)
+		if (hc->element->num_heaptids == 0)
 		{
 			so->w = list_delete_last(so->w);
 			continue;
 		}
 
-		heaptid = llast(hc->element->heaptids);
-
-		hc->element->heaptids = list_delete_last(hc->element->heaptids);
+		heaptid = HnswRemoveHeapTid(hc->element);
 
 		MemoryContextSwitchTo(oldCtx);
 
 #if PG_VERSION_NUM >= 120000
-		scan->xs_heaptid = *heaptid;
+		scan->xs_heaptid = heaptid;
 #else
-		scan->xs_ctup.t_self = *heaptid;
+		scan->xs_ctup.t_self = heaptid;
 #endif
 
 		scan->xs_recheckorderby = false;

--- a/src/hnswvacuum.c
+++ b/src/hnswvacuum.c
@@ -206,7 +206,7 @@ RepairGraphElement(HnswVacuumState * vacuumstate, HnswElement element, HnswEleme
 
 	/* Init fields */
 	HnswInitNeighbors(element, m);
-	element->heaptids = NIL;
+	element->num_heaptids = 0;
 
 	/* Add element to graph, skipping itself */
 	HnswInsertElement(element, entryPoint, index, procinfo, collation, m, efConstruction, true);


### PR DESCRIPTION
Avoid some palloc overhead, reducing the HNSW build memory usage.

The first three commits are the same as in PR #384. I built these on top of those patches, but could be applied separarely too. I'm ignoring those here, and focus on new changes.

1. First commit allocates the vector attached to an HnswElement in the same allocation as the HnswElement itself. That reduces memory usage by eliminating some palloc overhead.

   The reason I started to hack on this originally was to keep the vector as close as possible to 'hash' field, so that they would fit on the same cache line as often as possible. That way in HnswSearchLayer(), when you fetch the 'hash' to call AddToVisited(), you fetch the beginning of the vector too. That eliminates one cache miss stall for each visited neighbor. And I think I can see that effect in 'perf' profile: the cache miss showed up in the pg_detoast_datum() function, because that is the first dereference of the pointer when visiting an element, and that went down from about 15% to 2% of CPU usage with this commit. However, I'm not seeing any meaningful overall speedup in HNSW build. It seems that the cache stall just moved to the distance function itself. Perhaps the cpu cache readahead doesn't kick early enough, so that even if the first cache line of the vector is cached, you get a stall on the second one instead, until the read starts to work. In any case, this seems worth doing for the memory savings alone.

2. Save some more memory, by storing the 'heaptids' smarter. a PostgreSQL List is quite wasteful, especially when you palloc each element separately.

## Memory usage

After third commit (i.e. just the tracking, no reduction vs master): 63 MiB

```
2023-12-19 23:50:26.224 EET [335097] LOG:  memoryUsed: 50419632
2023-12-19 23:50:26.224 EET [335097] STATEMENT:  reindex index items_small_embedding_idx;
Hnsw in-memory build context: 67633200 total in 19 blocks; 4958072 free (12 chunks); 62675128 used
Grand total: 67633200 bytes in 19 blocks; 4958072 free (12 chunks); 62675128 used
```

With "Allocate HnswElement's vector value together with the struct": 59 MiB

```
2023-12-19 23:53:50.190 EET [335346] LOG:  memoryUsed: 50392432
2023-12-19 23:53:50.190 EET [335346] STATEMENT:  reindex index items_small_embedding_idx;
Hnsw in-memory build context: 59244592 total in 18 blocks; 197968 free (11 chunks); 59046624 used
Grand total: 59244592 bytes in 18 blocks; 197968 free (11 chunks); 59046624 used
```

With all commits: 54 MiB

```
2023-12-19 23:43:48.787 EET [334733] LOG:  memoryUsed: 50409024
2023-12-19 23:43:48.787 EET [334733] STATEMENT:  reindex index items_small_embedding_idx;
Hnsw in-memory build context: 59244592 total in 18 blocks; 4580296 free (15 chunks); 54664296 used
Grand total: 59244592 bytes in 18 blocks; 4580296 free (15 chunks); 54664296 used
```

So overall, memory usage was reduced from about 63 MiB to 59 MiB with the  55 MiB with this PR. The accounting estimates that this used 50 MiB, so we're still overshooting that by about 10%, but getting closer.