### PR TITLE
upgrade to 0.5.2; Increased max dimensions for index from 2000 to 4096

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+- Increased max dimensions for index from 2000 to 4096
+
 ## 0.5.1 (2023-10-10)
 
 - Improved performance of HNSW index builds

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXTENSION = vector
-EXTVERSION = 0.5.1
+EXTVERSION = 0.5.2
 
 MODULE_big = vector
 DATA = $(wildcard sql/*--*.sql)
@@ -63,7 +63,7 @@ prove_installcheck:
 
 dist:
 	mkdir -p dist
-	git archive --format zip --prefix=$(EXTENSION)-$(EXTVERSION)/ --output dist/$(EXTENSION)-$(EXTVERSION).zip master
+	git archive --format zip --prefix=$(EXTENSION)-$(EXTVERSION)/ --output dist/$(EXTENSION)-$(EXTVERSION).zip v0.5.2
 
 .PHONY: docker
 

--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ Then use `nmake` to build:
 
 ```cmd
 set "PGROOT=C:\Program Files\PostgreSQL\15"
-git clone --branch v0.5.1 https://github.com/pgvector/pgvector.git
+git clone --branch v0.5.2 https://github.com/pgvector/pgvector.git
 cd pgvector
 nmake /F Makefile.win
 nmake /F Makefile.win install

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -24,7 +24,7 @@
 #include "portability/instr_time.h"
 #endif
 
-#define IVFFLAT_MAX_DIM 2000
+#define IVFFLAT_MAX_DIM 4096
 
 /* Support functions */
 #define IVFFLAT_DISTANCE_PROC 1

--- a/vector.control
+++ b/vector.control
@@ -1,4 +1,4 @@
 comment = 'vector data type and ivfflat and hnsw access methods'
-default_version = '0.5.1'
+default_version = '0.5.2'
 module_pathname = '$libdir/vector'
 relocatable = true


### PR DESCRIPTION
# Increased max dimensions for index from 2000 to 4096

[Ollama generate embedding vector](https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-embeddings) with 4096 dimensions. So I increase the constant.