### PR TITLE
Simplify relptr stuff

### DIFF
--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -139,7 +139,7 @@ CreateElementPages(HnswBuildState * buildstate)
 	HnswElement entryPoint;
 	Buffer		buf;
 	Page		page;
-	HnswElementPtr iter = buildstate->graph->head;
+	HnswElementRelptr iter = buildstate->graph->head;
 	char	   *base = buildstate->hnswarea;
 
 	/* Calculate sizes */
@@ -235,7 +235,7 @@ CreateNeighborPages(HnswBuildState * buildstate)
 	Relation	index = buildstate->index;
 	ForkNumber	forkNum = buildstate->forkNum;
 	int			m = buildstate->m;
-	HnswElementPtr iter = buildstate->graph->head;
+	HnswElementRelptr iter = buildstate->graph->head;
 	char	   *base = buildstate->hnswarea;
 	HnswNeighborTuple ntup;
 
@@ -596,8 +596,8 @@ BuildCallback(Relation index, CALLBACK_ITEM_POINTER, Datum *values,
 static void
 InitGraph(HnswGraph * graph, char *base, long memoryTotal)
 {
-	HnswPtrSetNull(base, graph->head);
-	HnswPtrSetNull(base, graph->entryPoint);
+	HnswPtrStore(base, graph->head, (HnswElement) NULL);
+	HnswPtrStore(base, graph->entryPoint, (HnswElement) NULL);
 	graph->memoryUsed = 0;
 	graph->memoryTotal = memoryTotal;
 	graph->flushed = false;

--- a/src/hnswinsert.c
+++ b/src/hnswinsert.c
@@ -137,7 +137,7 @@ WriteNewElementPages(Relation index, HnswElement e, int m, BlockNumber insertPag
 	char	   *base = NULL;
 
 	/* Calculate sizes */
-	etupSize = HNSW_ELEMENT_TUPLE_SIZE(VARSIZE_ANY(HnswPtrAccess(base, e->value)));
+	etupSize = HNSW_ELEMENT_TUPLE_SIZE(VARSIZE_ANY(relptr_access(base, e->value)));
 	ntupSize = HNSW_NEIGHBOR_TUPLE_SIZE(e->level, m);
 	combinedSize = etupSize + ntupSize + sizeof(ItemIdData);
 	maxSize = HNSW_MAX_SIZE;
@@ -359,7 +359,7 @@ HnswUpdateNeighborPages(Relation index, FmgrInfo *procinfo, Oid collation, HnswE
 			Size		ntupSize;
 			int			idx = -1;
 			int			startIdx;
-			HnswElement neighborElement = HnswPtrAccess(base, hc->element);
+			HnswElement neighborElement = relptr_access(base, hc->element);
 			OffsetNumber offno = neighborElement->neighborOffno;
 
 			/* Get latest neighbors since they may have changed */
@@ -523,7 +523,7 @@ HnswFindDuplicate(Relation index, HnswElement element, bool building)
 	for (int i = 0; i < neighbors->length; i++)
 	{
 		HnswCandidate *neighbor = &neighbors->items[i];
-		HnswElement neighborElement = HnswPtrAccess(base, neighbor->element);
+		HnswElement neighborElement = relptr_access(base, neighbor->element);
 		Datum		value = HnswGetValue(base, element);
 		Datum		neighborValue = HnswGetValue(base, neighborElement);
 
@@ -592,7 +592,7 @@ HnswInsertTupleOnDisk(Relation index, Datum value, Datum *values, bool *isnull, 
 
 	/* Create an element */
 	element = HnswInitElement(base, heap_tid, m, HnswGetMl(m), HnswGetMaxLevel(m), NULL);
-	HnswPtrStore(base, element->value, DatumGetPointer(value));
+	relptr_store(base, element->value, DatumGetPointer(value));
 
 	/* Prevent concurrent inserts when likely updating entry point */
 	if (entryPoint == NULL || element->level > entryPoint->level)

--- a/src/hnswscan.c
+++ b/src/hnswscan.c
@@ -187,7 +187,7 @@ hnswgettuple(IndexScanDesc scan, ScanDirection dir)
 	{
 		char	   *base = NULL;
 		HnswCandidate *hc = llast(so->w);
-		HnswElement element = HnswPtrAccess(base, hc->element);
+		HnswElement element = relptr_access(base, hc->element);
 		ItemPointer heaptid;
 
 		/* Move to next element if no valid heap TIDs */

--- a/src/hnswvacuum.c
+++ b/src/hnswvacuum.c
@@ -301,7 +301,7 @@ RepairGraphEntryPoint(HnswVacuumState * vacuumstate)
 			{
 				/* Reset neighbors from previous update */
 				if (highestPoint != NULL)
-					HnswPtrStore((char *) NULL, highestPoint->neighbors, (HnswNeighborArrayRelptr *) NULL);
+					relptr_store((char *) NULL, highestPoint->neighbors, (HnswNeighborArrayRelptr *) NULL);
 
 				RepairGraphElement(vacuumstate, entryPoint, highestPoint);
 			}

--- a/src/hnswvacuum.c
+++ b/src/hnswvacuum.c
@@ -301,7 +301,7 @@ RepairGraphEntryPoint(HnswVacuumState * vacuumstate)
 			{
 				/* Reset neighbors from previous update */
 				if (highestPoint != NULL)
-					HnswPtrSetNull(NULL, highestPoint->neighbors);
+					HnswPtrStore((char *) NULL, highestPoint->neighbors, (HnswNeighborArrayRelptr *) NULL);
 
 				RepairGraphElement(vacuumstate, entryPoint, highestPoint);
 			}


### PR DESCRIPTION
I'm reviewing the parallel in-memory HNSW changes at https://github.com/pgvector/pgvector/compare/hnsw-fast-build..

I didn't understand the point of the pointer types that could hold absolute or relative pointers. Let's just always use the relative pointers? Sure, in a non-parallel build, you could use absolute pointers, but it seems simpler to always use relative ones.