### PR TITLE
Little cleanups to the parallel HNSW build branch

### DIFF
--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -212,7 +212,6 @@ typedef struct HnswShared
 	Oid			heaprelid;
 	Oid			indexrelid;
 	bool		isconcurrent;
-	int			scantuplesortstates;
 
 	/* Worker progress */
 	ConditionVariable workersdonecv;

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -200,12 +200,6 @@ typedef struct HnswGraph
 	bool		flushed;
 }			HnswGraph;
 
-typedef struct HnswSpool
-{
-	Relation	heap;
-	Relation	index;
-}			HnswSpool;
-
 typedef struct HnswShared
 {
 	/* Immutable state */

--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -382,7 +382,7 @@ HnswUpdateNeighborPagesInMemory(char *base, FmgrInfo *procinfo, Oid collation, H
  * Write changes in memory
  */
 static void
-WriteElementInMemory(Relation index, FmgrInfo *procinfo, Oid collation, HnswElement element, int m, int efConstruction, HnswElement entryPoint, HnswBuildState * buildstate, HnswGraph * graph, bool updateEntryPoint)
+WriteElementInMemory(FmgrInfo *procinfo, Oid collation, HnswElement element, int m, int efConstruction, HnswElement entryPoint, HnswBuildState * buildstate, HnswGraph * graph, bool updateEntryPoint)
 {
 	char	   *base = buildstate->hnswarea;
 
@@ -497,7 +497,7 @@ InsertTuple(Relation index, Datum *values, bool *isnull, ItemPointer heaptid, Hn
 	HnswInsertElement(base, element, entryPoint, NULL, procinfo, collation, m, efConstruction, false);
 
 	/* Write to memory */
-	WriteElementInMemory(index, procinfo, collation, element, m, efConstruction, entryPoint, buildstate, graph, updateEntryPoint);
+	WriteElementInMemory(procinfo, collation, element, m, efConstruction, entryPoint, buildstate, graph, updateEntryPoint);
 
 	/* Release lock if needed */
 	if (updateEntryPoint)

--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -885,7 +885,6 @@ static void
 HnswBeginParallel(HnswBuildState * buildstate, bool isconcurrent, int request)
 {
 	ParallelContext *pcxt;
-	int			scantuplesortstates;
 	Snapshot	snapshot;
 	Size		esthnswshared;
 	Size		esthnswarea;
@@ -908,8 +907,6 @@ HnswBeginParallel(HnswBuildState * buildstate, bool isconcurrent, int request)
 #else
 	pcxt = CreateParallelContext("vector", "HnswParallelBuildMain", request, true);
 #endif
-
-	scantuplesortstates = leaderparticipates ? request + 1 : request;
 
 	/* Get snapshot for table scan */
 	if (!isconcurrent)
@@ -961,7 +958,6 @@ HnswBeginParallel(HnswBuildState * buildstate, bool isconcurrent, int request)
 	hnswshared->heaprelid = RelationGetRelid(buildstate->heap);
 	hnswshared->indexrelid = RelationGetRelid(buildstate->index);
 	hnswshared->isconcurrent = isconcurrent;
-	hnswshared->scantuplesortstates = scantuplesortstates;
 	ConditionVariableInit(&hnswshared->workersdonecv);
 	SpinLockInit(&hnswshared->mutex);
 	/* Initialize mutable state */


### PR DESCRIPTION
The first two commits remove an unused field and an argument. The third commit removes HnswSpool, it seems unnecessary to me. Per commit message:

Remove HnswSpool
    
It was just used to pass heap/index relations to
HnswParallelScanAndInsert. I think it was copied from nbtsort.c, which
is more complicated. I don't think we need a struct like this.

(That said, I actually think that we should have a state object that
would hold fields like 'heap', 'index', 'procinfo', 'collation'
etc. Passing that object around would simplify the signatures of many
functions. But that's a different story).
