### PR TITLE
Update cost estimation to not use index when expected tuples is too low

### DIFF
--- a/src/ivfflat.c
+++ b/src/ivfflat.c
@@ -112,7 +112,7 @@ ivfflatcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 	{
 		RestrictInfo *rinfo = lfirst(lc);
 
-		if (rinfo->norm_selec >= 0 && rinfo->norm_selec <= 1 && rinfo->norm_selec != DEFAULT_INEQ_SEL)
+		if (rinfo->norm_selec >= 0 && rinfo->norm_selec <= 1 && rinfo->norm_selec != (Selectivity) DEFAULT_INEQ_SEL)
 			selectivity *= rinfo->norm_selec;
 	}
 

--- a/test/expected/hnsw_cosine.out
+++ b/test/expected/hnsw_cosine.out
@@ -3,7 +3,7 @@ CREATE TABLE t (val vector(3));
 INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
 CREATE INDEX ON t USING hnsw (val vector_cosine_ops);
 INSERT INTO t (val) VALUES ('[1,2,4]');
-SELECT * FROM t ORDER BY val <=> '[3,3,3]';
+SELECT * FROM t ORDER BY val <=> '[3,3,3]' LIMIT 5;
    val   
 ---------
  [1,1,1]
@@ -11,13 +11,13 @@ SELECT * FROM t ORDER BY val <=> '[3,3,3]';
  [1,2,4]
 (3 rows)
 
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> '[0,0,0]') t2;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> '[0,0,0]' LIMIT 5) t2;
  count 
 -------
      3
 (1 row)
 
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> (SELECT NULL::vector)) t2;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> (SELECT NULL::vector) LIMIT 5) t2;
  count 
 -------
      3

--- a/test/expected/hnsw_ip.out
+++ b/test/expected/hnsw_ip.out
@@ -3,7 +3,7 @@ CREATE TABLE t (val vector(3));
 INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
 CREATE INDEX ON t USING hnsw (val vector_ip_ops);
 INSERT INTO t (val) VALUES ('[1,2,4]');
-SELECT * FROM t ORDER BY val <#> '[3,3,3]';
+SELECT * FROM t ORDER BY val <#> '[3,3,3]' LIMIT 5;
    val   
 ---------
  [1,2,4]
@@ -12,7 +12,7 @@ SELECT * FROM t ORDER BY val <#> '[3,3,3]';
  [0,0,0]
 (4 rows)
 
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <#> (SELECT NULL::vector)) t2;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <#> (SELECT NULL::vector) LIMIT 5) t2;
  count 
 -------
      4

--- a/test/expected/hnsw_l2.out
+++ b/test/expected/hnsw_l2.out
@@ -3,7 +3,7 @@ CREATE TABLE t (val vector(3));
 INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
 CREATE INDEX ON t USING hnsw (val vector_l2_ops);
 INSERT INTO t (val) VALUES ('[1,2,4]');
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
    val   
 ---------
  [1,2,3]
@@ -12,7 +12,7 @@ SELECT * FROM t ORDER BY val <-> '[3,3,3]';
  [0,0,0]
 (4 rows)
 
-SELECT * FROM t ORDER BY val <-> (SELECT NULL::vector);
+SELECT * FROM t ORDER BY val <-> (SELECT NULL::vector) LIMIT 5;
    val   
 ---------
  [0,0,0]
@@ -28,7 +28,7 @@ SELECT COUNT(*) FROM t;
 (1 row)
 
 TRUNCATE t;
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
  val 
 -----
 (0 rows)

--- a/test/expected/hnsw_unlogged.out
+++ b/test/expected/hnsw_unlogged.out
@@ -2,7 +2,7 @@ SET enable_seqscan = off;
 CREATE UNLOGGED TABLE t (val vector(3));
 INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
 CREATE INDEX ON t USING hnsw (val vector_l2_ops);
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
    val   
 ---------
  [1,2,3]

--- a/test/expected/ivfflat_cosine.out
+++ b/test/expected/ivfflat_cosine.out
@@ -3,7 +3,7 @@ CREATE TABLE t (val vector(3));
 INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
 CREATE INDEX ON t USING ivfflat (val vector_cosine_ops) WITH (lists = 1);
 INSERT INTO t (val) VALUES ('[1,2,4]');
-SELECT * FROM t ORDER BY val <=> '[3,3,3]';
+SELECT * FROM t ORDER BY val <=> '[3,3,3]' LIMIT 5;
    val   
 ---------
  [1,1,1]
@@ -11,13 +11,13 @@ SELECT * FROM t ORDER BY val <=> '[3,3,3]';
  [1,2,4]
 (3 rows)
 
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> '[0,0,0]') t2;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> '[0,0,0]' LIMIT 5) t2;
  count 
 -------
      3
 (1 row)
 
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> (SELECT NULL::vector)) t2;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> (SELECT NULL::vector) LIMIT 5) t2;
  count 
 -------
      3

--- a/test/expected/ivfflat_ip.out
+++ b/test/expected/ivfflat_ip.out
@@ -3,7 +3,7 @@ CREATE TABLE t (val vector(3));
 INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
 CREATE INDEX ON t USING ivfflat (val vector_ip_ops) WITH (lists = 1);
 INSERT INTO t (val) VALUES ('[1,2,4]');
-SELECT * FROM t ORDER BY val <#> '[3,3,3]';
+SELECT * FROM t ORDER BY val <#> '[3,3,3]' LIMIT 5;
    val   
 ---------
  [1,2,4]
@@ -12,7 +12,7 @@ SELECT * FROM t ORDER BY val <#> '[3,3,3]';
  [0,0,0]
 (4 rows)
 
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <#> (SELECT NULL::vector)) t2;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <#> (SELECT NULL::vector) LIMIT 5) t2;
  count 
 -------
      4

--- a/test/expected/ivfflat_l2.out
+++ b/test/expected/ivfflat_l2.out
@@ -3,7 +3,7 @@ CREATE TABLE t (val vector(3));
 INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
 CREATE INDEX ON t USING ivfflat (val vector_l2_ops) WITH (lists = 1);
 INSERT INTO t (val) VALUES ('[1,2,4]');
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
    val   
 ---------
  [1,2,3]
@@ -12,7 +12,7 @@ SELECT * FROM t ORDER BY val <-> '[3,3,3]';
  [0,0,0]
 (4 rows)
 
-SELECT * FROM t ORDER BY val <-> (SELECT NULL::vector);
+SELECT * FROM t ORDER BY val <-> (SELECT NULL::vector) LIMIT 5;
    val   
 ---------
  [0,0,0]
@@ -31,7 +31,7 @@ TRUNCATE t;
 NOTICE:  ivfflat index created with little data
 DETAIL:  This will cause low recall.
 HINT:  Drop the index until the table has more data.
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
  val 
 -----
 (0 rows)

--- a/test/expected/ivfflat_unlogged.out
+++ b/test/expected/ivfflat_unlogged.out
@@ -2,7 +2,7 @@ SET enable_seqscan = off;
 CREATE UNLOGGED TABLE t (val vector(3));
 INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
 CREATE INDEX ON t USING ivfflat (val vector_l2_ops) WITH (lists = 1);
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
    val   
 ---------
  [1,2,3]

--- a/test/sql/hnsw_cosine.sql
+++ b/test/sql/hnsw_cosine.sql
@@ -6,8 +6,8 @@ CREATE INDEX ON t USING hnsw (val vector_cosine_ops);
 
 INSERT INTO t (val) VALUES ('[1,2,4]');
 
-SELECT * FROM t ORDER BY val <=> '[3,3,3]';
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> '[0,0,0]') t2;
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> (SELECT NULL::vector)) t2;
+SELECT * FROM t ORDER BY val <=> '[3,3,3]' LIMIT 5;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> '[0,0,0]' LIMIT 5) t2;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> (SELECT NULL::vector) LIMIT 5) t2;
 
 DROP TABLE t;

--- a/test/sql/hnsw_ip.sql
+++ b/test/sql/hnsw_ip.sql
@@ -6,7 +6,7 @@ CREATE INDEX ON t USING hnsw (val vector_ip_ops);
 
 INSERT INTO t (val) VALUES ('[1,2,4]');
 
-SELECT * FROM t ORDER BY val <#> '[3,3,3]';
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <#> (SELECT NULL::vector)) t2;
+SELECT * FROM t ORDER BY val <#> '[3,3,3]' LIMIT 5;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <#> (SELECT NULL::vector) LIMIT 5) t2;
 
 DROP TABLE t;

--- a/test/sql/hnsw_l2.sql
+++ b/test/sql/hnsw_l2.sql
@@ -6,11 +6,11 @@ CREATE INDEX ON t USING hnsw (val vector_l2_ops);
 
 INSERT INTO t (val) VALUES ('[1,2,4]');
 
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
-SELECT * FROM t ORDER BY val <-> (SELECT NULL::vector);
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
+SELECT * FROM t ORDER BY val <-> (SELECT NULL::vector) LIMIT 5;
 SELECT COUNT(*) FROM t;
 
 TRUNCATE t;
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
 
 DROP TABLE t;

--- a/test/sql/hnsw_unlogged.sql
+++ b/test/sql/hnsw_unlogged.sql
@@ -4,6 +4,6 @@ CREATE UNLOGGED TABLE t (val vector(3));
 INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
 CREATE INDEX ON t USING hnsw (val vector_l2_ops);
 
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
 
 DROP TABLE t;

--- a/test/sql/ivfflat_cosine.sql
+++ b/test/sql/ivfflat_cosine.sql
@@ -6,8 +6,8 @@ CREATE INDEX ON t USING ivfflat (val vector_cosine_ops) WITH (lists = 1);
 
 INSERT INTO t (val) VALUES ('[1,2,4]');
 
-SELECT * FROM t ORDER BY val <=> '[3,3,3]';
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> '[0,0,0]') t2;
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> (SELECT NULL::vector)) t2;
+SELECT * FROM t ORDER BY val <=> '[3,3,3]' LIMIT 5;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> '[0,0,0]' LIMIT 5) t2;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <=> (SELECT NULL::vector) LIMIT 5) t2;
 
 DROP TABLE t;

--- a/test/sql/ivfflat_ip.sql
+++ b/test/sql/ivfflat_ip.sql
@@ -6,7 +6,7 @@ CREATE INDEX ON t USING ivfflat (val vector_ip_ops) WITH (lists = 1);
 
 INSERT INTO t (val) VALUES ('[1,2,4]');
 
-SELECT * FROM t ORDER BY val <#> '[3,3,3]';
-SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <#> (SELECT NULL::vector)) t2;
+SELECT * FROM t ORDER BY val <#> '[3,3,3]' LIMIT 5;
+SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <#> (SELECT NULL::vector) LIMIT 5) t2;
 
 DROP TABLE t;

--- a/test/sql/ivfflat_l2.sql
+++ b/test/sql/ivfflat_l2.sql
@@ -6,11 +6,11 @@ CREATE INDEX ON t USING ivfflat (val vector_l2_ops) WITH (lists = 1);
 
 INSERT INTO t (val) VALUES ('[1,2,4]');
 
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
-SELECT * FROM t ORDER BY val <-> (SELECT NULL::vector);
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
+SELECT * FROM t ORDER BY val <-> (SELECT NULL::vector) LIMIT 5;
 SELECT COUNT(*) FROM t;
 
 TRUNCATE t;
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
 
 DROP TABLE t;

--- a/test/sql/ivfflat_unlogged.sql
+++ b/test/sql/ivfflat_unlogged.sql
@@ -4,6 +4,6 @@ CREATE UNLOGGED TABLE t (val vector(3));
 INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
 CREATE INDEX ON t USING ivfflat (val vector_l2_ops) WITH (lists = 1);
 
-SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+SELECT * FROM t ORDER BY val <-> '[3,3,3]' LIMIT 5;
 
 DROP TABLE t;

--- a/test/t/007_ivfflat_inserts.pl
+++ b/test/t/007_ivfflat_inserts.pl
@@ -49,7 +49,7 @@ is(idx_scan(), 0);
 $count = $node->safe_psql("postgres", qq(
 	SET enable_seqscan = off;
 	SET ivfflat.probes = 100;
-	SELECT COUNT(*) FROM (SELECT v FROM tst ORDER BY v <-> (SELECT v FROM tst LIMIT 1)) t;
+	SELECT COUNT(*) FROM (SELECT v FROM tst ORDER BY v <-> (SELECT v FROM tst LIMIT 1) LIMIT 20000) t;
 ));
 is($count, $expected);
 is(idx_scan(), 1);

--- a/test/t/014_hnsw_inserts.pl
+++ b/test/t/014_hnsw_inserts.pl
@@ -42,7 +42,7 @@ for my $i (1 .. 20)
 
 	my $count = $node->safe_psql("postgres", qq(
 		SET enable_seqscan = off;
-		SELECT COUNT(*) FROM (SELECT v FROM tst ORDER BY v <-> (SELECT v FROM tst LIMIT 1)) t;
+		SELECT COUNT(*) FROM (SELECT v FROM tst ORDER BY v <-> (SELECT v FROM tst LIMIT 1) LIMIT 20) t;
 	));
 	is($count, 10);
 
@@ -63,7 +63,7 @@ $node->pgbench(
 my $count = $node->safe_psql("postgres", qq(
 	SET enable_seqscan = off;
 	SET hnsw.ef_search = 1000;
-	SELECT COUNT(*) FROM (SELECT v FROM tst ORDER BY v <-> (SELECT v FROM tst LIMIT 1)) t;
+	SELECT COUNT(*) FROM (SELECT v FROM tst ORDER BY v <-> (SELECT v FROM tst LIMIT 1) LIMIT 1000) t;
 ));
 # Elements may lose all incoming connections with the HNSW algorithm
 # Vacuuming can fix this if one of the elements neighbors is deleted

--- a/test/t/015_hnsw_duplicates.pl
+++ b/test/t/015_hnsw_duplicates.pl
@@ -26,7 +26,7 @@ sub test_duplicates
 	my $res = $node->safe_psql("postgres", qq(
 		SET enable_seqscan = off;
 		SET hnsw.ef_search = 1;
-		SELECT COUNT(*) FROM (SELECT * FROM tst ORDER BY v <-> '[1,1,1]') t;
+		SELECT COUNT(*) FROM (SELECT * FROM tst ORDER BY v <-> '[1,1,1]' LIMIT 20) t;
 	));
 	is($res, 10);
 }

--- a/test/t/018_hnsw_filtering.pl
+++ b/test/t/018_hnsw_filtering.pl
@@ -17,9 +17,9 @@ $node->start;
 
 # Create table and index
 $node->safe_psql("postgres", "CREATE EXTENSION vector;");
-$node->safe_psql("postgres", "CREATE TABLE tst (i int4, v vector($dim), c int4);");
+$node->safe_psql("postgres", "CREATE TABLE tst (i int4, v vector($dim), c int4, t text);");
 $node->safe_psql("postgres",
-	"INSERT INTO tst SELECT i, ARRAY[$array_sql], i % $nc FROM generate_series(1, 10000) i;"
+	"INSERT INTO tst SELECT i, ARRAY[$array_sql], i % $nc, 'test ' || i FROM generate_series(1, 10000) i;"
 );
 $node->safe_psql("postgres", "CREATE INDEX idx ON tst USING hnsw (v vector_l2_ops);");
 $node->safe_psql("postgres", "ANALYZE tst;");
@@ -54,6 +54,18 @@ like($explain, qr/Index Scan using idx/);
 # Test attribute filtering with many rows removed comparison
 $explain = $node->safe_psql("postgres", qq(
 	EXPLAIN ANALYZE SELECT i FROM tst WHERE c < 1 ORDER BY v <-> '$query' LIMIT $limit;
+));
+like($explain, qr/Seq Scan/);
+
+# Test attribute filtering with few rows removed like
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT i FROM tst WHERE t LIKE '%%test%%' ORDER BY v <-> '$query' LIMIT $limit;
+));
+like($explain, qr/Index Scan using idx/);
+
+# Test attribute filtering with many rows removed like
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT i FROM tst WHERE t LIKE '%%other%%' ORDER BY v <-> '$query' LIMIT $limit;
 ));
 like($explain, qr/Seq Scan/);
 

--- a/test/t/018_hnsw_filtering.pl
+++ b/test/t/018_hnsw_filtering.pl
@@ -36,8 +36,7 @@ my $c = int(rand() * $nc);
 my $explain = $node->safe_psql("postgres", qq(
 	EXPLAIN ANALYZE SELECT i FROM tst WHERE c = $c ORDER BY v <-> '$query' LIMIT $limit;
 ));
-# TODO Do not use index
-like($explain, qr/Index Scan using idx/);
+like($explain, qr/Seq Scan/);
 
 # Test attribute filtering with few rows removed
 $explain = $node->safe_psql("postgres", qq(

--- a/test/t/019_ivfflat_filtering.pl
+++ b/test/t/019_ivfflat_filtering.pl
@@ -36,8 +36,7 @@ my $c = int(rand() * $nc);
 my $explain = $node->safe_psql("postgres", qq(
 	EXPLAIN ANALYZE SELECT i FROM tst WHERE c = $c ORDER BY v <-> '$query' LIMIT $limit;
 ));
-# TODO Do not use index
-like($explain, qr/Index Scan using idx/);
+like($explain, qr/Seq Scan/);
 
 # Test attribute filtering with few rows removed
 $explain = $node->safe_psql("postgres", qq(
@@ -68,8 +67,7 @@ like($explain, qr/Seq Scan/);
 $explain = $node->safe_psql("postgres", qq(
 	EXPLAIN ANALYZE SELECT i FROM tst WHERE v <-> '$query' < 1 ORDER BY v <-> '$query';
 ));
-# TODO Do not use index
-like($explain, qr/Index Scan using idx/);
+like($explain, qr/Seq Scan/);
 
 # Test attribute index
 $node->safe_psql("postgres", "CREATE INDEX attribute_idx ON tst (c);");

--- a/test/t/019_ivfflat_filtering.pl
+++ b/test/t/019_ivfflat_filtering.pl
@@ -22,6 +22,7 @@ $node->safe_psql("postgres",
 	"INSERT INTO tst SELECT i, ARRAY[$array_sql], i % $nc FROM generate_series(1, 10000) i;"
 );
 $node->safe_psql("postgres", "CREATE INDEX idx ON tst USING ivfflat (v vector_l2_ops) WITH (lists = 100);");
+$node->safe_psql("postgres", "ANALYZE tst;");
 
 # Generate query
 my @r = ();
@@ -43,6 +44,18 @@ $explain = $node->safe_psql("postgres", qq(
 	EXPLAIN ANALYZE SELECT i FROM tst WHERE c != $c ORDER BY v <-> '$query' LIMIT $limit;
 ));
 like($explain, qr/Index Scan using idx/);
+
+# Test attribute filtering with few rows removed comparison
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT i FROM tst WHERE c >= 1 ORDER BY v <-> '$query' LIMIT $limit;
+));
+like($explain, qr/Index Scan using idx/);
+
+# Test attribute filtering with many rows removed comparison
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT i FROM tst WHERE c < 1 ORDER BY v <-> '$query' LIMIT $limit;
+));
+like($explain, qr/Seq Scan/);
 
 # Test distance filtering
 $explain = $node->safe_psql("postgres", qq(

--- a/test/t/020_ivfflat_limit.pl
+++ b/test/t/020_ivfflat_limit.pl
@@ -1,0 +1,64 @@
+use strict;
+use warnings;
+use PostgresNode;
+use TestLib;
+use Test::More;
+
+# Initialize node
+my $node = get_new_node('node');
+$node->init;
+$node->start;
+
+# Create table and index
+$node->safe_psql("postgres", "CREATE EXTENSION vector;");
+$node->safe_psql("postgres", "CREATE TABLE tst (v vector(3));");
+$node->safe_psql("postgres",
+	"INSERT INTO tst SELECT ARRAY[random(), random(), random()] FROM generate_series(1, 1000) i;"
+);
+$node->safe_psql("postgres", "CREATE INDEX ON tst USING ivfflat (v vector_l2_ops) WITH (lists = 10);");
+
+# Test limit
+my $explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 100;
+));
+like($explain, qr/Index Scan/);
+
+# Test limit with probes
+$explain = $node->safe_psql("postgres", qq(
+	SET ivfflat.probes = 2;
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 200;
+));
+like($explain, qr/Index Scan/);
+
+# Test limit + offset
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 90 OFFSET 10;
+));
+like($explain, qr/Index Scan/);
+
+# Test limit > expected tuples
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 101;
+));
+like($explain, qr/Seq Scan/);
+
+# Test limit > expected tuples with probes
+$explain = $node->safe_psql("postgres", qq(
+	SET ivfflat.probes = 2;
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 201;
+));
+like($explain, qr/Seq Scan/);
+
+# Test limit + offset > expected tuples
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 91 OFFSET 10;
+));
+like($explain, qr/Seq Scan/);
+
+# Test no limit
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]';
+));
+like($explain, qr/Seq Scan/);
+
+done_testing();

--- a/test/t/021_hnsw_limit.pl
+++ b/test/t/021_hnsw_limit.pl
@@ -1,0 +1,62 @@
+use strict;
+use warnings;
+use PostgresNode;
+use TestLib;
+use Test::More;
+
+# Initialize node
+my $node = get_new_node('node');
+$node->init;
+$node->start;
+
+# Create table and index
+$node->safe_psql("postgres", "CREATE EXTENSION vector;");
+$node->safe_psql("postgres", "CREATE TABLE tst (v vector(3));");
+$node->safe_psql("postgres",
+	"INSERT INTO tst SELECT ARRAY[random(), random(), random()] FROM generate_series(1, 1000) i;"
+);
+$node->safe_psql("postgres", "CREATE INDEX ON tst USING hnsw (v vector_l2_ops);");
+
+# Test limit
+my $explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 40;
+));
+like($explain, qr/Index Scan/);
+
+# Test limit with CTE
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE WITH cte AS (SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 40) SELECT * FROM cte;
+));
+like($explain, qr/Index Scan/);
+
+# Test limit + offset
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 30 OFFSET 10;
+));
+like($explain, qr/Index Scan/);
+
+# Test limit > ef_search
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 41;
+));
+like($explain, qr/Seq Scan/);
+
+# Test limit > ef_search with CTE
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE WITH cte AS (SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 41) SELECT * FROM cte;
+));
+like($explain, qr/Seq Scan/);
+
+# Test limit + offset > ef_search
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]' LIMIT 31 OFFSET 10;
+));
+like($explain, qr/Seq Scan/);
+
+# Test no limit
+$explain = $node->safe_psql("postgres", qq(
+	EXPLAIN ANALYZE SELECT * FROM tst ORDER BY v <-> '[1,2,3]';
+));
+like($explain, qr/Seq Scan/);
+
+done_testing();


### PR DESCRIPTION
Hi all, wanted to get feedback on this change.

This PR updates cost estimation to not an index if the expected number of tuples to be returned is less than the number requested by the user. A few situations where this happens are:

1. A large % of rows being filtered - #263
2. Limit + offset > ef_search (HNSW) - #396
3. Limit + offset > probes * vectors per list (IVFFlat) - #405

See TAP tests 018 through 021 for specific queries. The costs are set so users can still override this with `SET enable_seqscan = off;` (except in the case of no `LIMIT`).

Let me know if you have any thoughts.