### PR TITLE
#include nitpicking

### DIFF
--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -4,6 +4,7 @@
 #include <math.h>
 
 #include "access/amapi.h"
+#include "access/reloptions.h"
 #include "commands/progress.h"
 #include "commands/vacuum.h"
 #include "hnsw.h"

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -6,6 +6,7 @@
 #include "access/generic_xlog.h"
 #include "access/parallel.h"
 #include "access/reloptions.h"
+#include "lib/pairingheap.h"
 #include "nodes/execnodes.h"
 #include "port.h"				/* for random() */
 #include "utils/relptr.h"

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -4,7 +4,6 @@
 #include "postgres.h"
 
 #include "access/genam.h"
-#include "access/generic_xlog.h"
 #include "access/parallel.h"
 #include "lib/pairingheap.h"
 #include "nodes/execnodes.h"

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -3,9 +3,9 @@
 
 #include "postgres.h"
 
+#include "access/genam.h"
 #include "access/generic_xlog.h"
 #include "access/parallel.h"
-#include "access/reloptions.h"
 #include "lib/pairingheap.h"
 #include "nodes/execnodes.h"
 #include "port.h"				/* for random() */

--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -46,7 +46,6 @@
 #include "commands/progress.h"
 #include "hnsw.h"
 #include "miscadmin.h"
-#include "lib/pairingheap.h"
 #include "optimizer/optimizer.h"
 #include "storage/bufmgr.h"
 #include "tcop/tcopprot.h"

--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -42,6 +42,7 @@
 #include "access/table.h"
 #include "access/tableam.h"
 #include "access/xact.h"
+#include "access/xloginsert.h"
 #include "catalog/index.h"
 #include "commands/progress.h"
 #include "hnsw.h"

--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -47,7 +47,6 @@
 #include "hnsw.h"
 #include "miscadmin.h"
 #include "lib/pairingheap.h"
-#include "nodes/pg_list.h"
 #include "optimizer/optimizer.h"
 #include "storage/bufmgr.h"
 #include "tcop/tcopprot.h"

--- a/src/hnswinsert.c
+++ b/src/hnswinsert.c
@@ -2,6 +2,7 @@
 
 #include <math.h>
 
+#include "access/generic_xlog.h"
 #include "hnsw.h"
 #include "storage/bufmgr.h"
 #include "storage/lmgr.h"

--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -2,10 +2,12 @@
 
 #include <math.h>
 
+#include "access/generic_xlog.h"
 #include "hnsw.h"
 #include "lib/pairingheap.h"
 #include "storage/bufmgr.h"
 #include "utils/datum.h"
+#include "utils/rel.h"
 #include "vector.h"
 
 #if PG_VERSION_NUM >= 130000

--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -3,6 +3,7 @@
 #include <math.h>
 
 #include "hnsw.h"
+#include "lib/pairingheap.h"
 #include "storage/bufmgr.h"
 #include "utils/datum.h"
 #include "vector.h"

--- a/src/hnswvacuum.c
+++ b/src/hnswvacuum.c
@@ -2,6 +2,7 @@
 
 #include <math.h>
 
+#include "access/generic_xlog.h"
 #include "commands/vacuum.h"
 #include "hnsw.h"
 #include "storage/bufmgr.h"

--- a/src/ivfflat.c
+++ b/src/ivfflat.c
@@ -3,6 +3,7 @@
 #include <float.h>
 
 #include "access/amapi.h"
+#include "access/reloptions.h"
 #include "commands/progress.h"
 #include "commands/vacuum.h"
 #include "ivfflat.h"

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -6,6 +6,7 @@
 #include "access/generic_xlog.h"
 #include "access/parallel.h"
 #include "access/reloptions.h"
+#include "lib/pairingheap.h"
 #include "nodes/execnodes.h"
 #include "port.h"				/* for random() */
 #include "utils/sampling.h"

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -3,9 +3,9 @@
 
 #include "postgres.h"
 
+#include "access/genam.h"
 #include "access/generic_xlog.h"
 #include "access/parallel.h"
-#include "access/reloptions.h"
 #include "lib/pairingheap.h"
 #include "nodes/execnodes.h"
 #include "port.h"				/* for random() */

--- a/src/ivfinsert.c
+++ b/src/ivfinsert.c
@@ -2,6 +2,7 @@
 
 #include <float.h>
 
+#include "access/generic_xlog.h"
 #include "ivfflat.h"
 #include "storage/bufmgr.h"
 #include "storage/lmgr.h"

--- a/src/ivfscan.c
+++ b/src/ivfscan.c
@@ -5,6 +5,7 @@
 #include "access/relscan.h"
 #include "catalog/pg_operator_d.h"
 #include "catalog/pg_type_d.h"
+#include "lib/pairingheap.h"
 #include "ivfflat.h"
 #include "miscadmin.h"
 #include "pgstat.h"

--- a/src/ivfutils.c
+++ b/src/ivfutils.c
@@ -1,5 +1,6 @@
 #include "postgres.h"
 
+#include "access/generic_xlog.h"
 #include "ivfflat.h"
 #include "storage/bufmgr.h"
 #include "vector.h"

--- a/src/ivfvacuum.c
+++ b/src/ivfvacuum.c
@@ -1,5 +1,6 @@
 #include "postgres.h"
 
+#include "access/generic_xlog.h"
 #include "commands/vacuum.h"
 #include "ivfflat.h"
 #include "storage/bufmgr.h"


### PR DESCRIPTION
See commit messages for details.

I started doing this when I noticed that  the `#include "miscadmin.h"` in `hnswbuild.c` was out of alphabetical order. The first two commits in this PR fix that by eliminating the `lib/pairingheap.h` and `nodes/pg_list.h` includes after `miscadmin.h`. 

The other two commits eliminate some indirect including. There's plenty of relying on indirect includes left in the codebase, and I don't think we should be religious about it, especially when the headers in upstream PostgreSQL change in every major release. But these two cases seem nice to clean up.