### PR TITLE
Reduce fruitless scanning of caches in CheckElementCloser

### DIFF
--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -390,6 +390,10 @@ void		HnswUpdateConnection(char *base, HnswElement element, HnswCandidate * hc, 
 void		HnswLoadNeighbors(HnswElement element, Relation index, int m);
 PGDLLEXPORT void HnswParallelBuildMain(dsm_segment *seg, shm_toc *toc);
 
+
+extern void HnswResetStats(void);
+extern void HnswPrintStats(void);
+
 /* Index access methods */
 IndexBuildResult *hnswbuild(Relation heap, Relation index, IndexInfo *indexInfo);
 void		hnswbuildempty(Relation index);

--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -1052,6 +1052,8 @@ BuildGraph(HnswBuildState * buildstate, ForkNumber forkNum)
 	if (buildstate->heap != NULL)
 		parallel_workers = ComputeParallelWorkers(buildstate->heap, buildstate->index);
 
+	HnswResetStats();
+
 	/* Attempt to launch parallel worker scan when required */
 	if (parallel_workers > 0)
 		HnswBeginParallel(buildstate, buildstate->indexInfo->ii_Concurrent, parallel_workers);
@@ -1068,6 +1070,8 @@ BuildGraph(HnswBuildState * buildstate, ForkNumber forkNum)
 		buildstate->indtuples = buildstate->graph->indtuples;
 	}
 
+	HnswPrintStats();
+	
 	/* Flush pages */
 	if (!buildstate->graph->flushed)
 		FlushPages(buildstate);


### PR DESCRIPTION
@ankane, I saw that you removed the checking the caches in CheckElementCloser altogether in commit 0cc883b944d5c819ebb3d6d331938715af7a441d. +0.5 on that, I'm also not convinced that scanning the cache was worth it and removing it improves performance in the test case I've mostly been using, with 100-dimension vectors and ef=16. I wonder if the caching would be beneficial with higher dimensions though, which is why I haven't dared to propose removing it altogether. What kind of benchmarking did you do on that?

Anyway, here's a patch I had been working on to eliminate some fruitless scanning of those caches. It's moot if we remove the caching altogether, of course.

This patch is based on the observation that when you are inserting a new element to the graph, no other element can have an edge pointing to the new element yet, so its pointless to search for one. That's not strictly true: in case of parallel inserts to the neighbors, another backend might have added such an edge before the inserting backend has finished updating all the neighbors. That's extremely rate but it means that we cannot e.g. have an assertion on it either.

The first commit in this PR introduces the optimization.  The 2nd commit prints a bunch of counters to demonstrate the effect; that's not meant to be merged.

Stats from the 2nd commit with the patch:
```
NOTICE:  distance_calcs GetCandidateDistance:  104495038
NOTICE:  distance_calcs CheckElementCloser:     54745306
NOTICE:     cache_hit_a:    3500481
NOTICE:    cache_miss_a:   45269678
NOTICE:     cache_hit_b:    1120600
NOTICE:    cache_miss_b:   42645542
NOTICE:     cache_miss:    54745306
```

And without the patch:
```
NOTICE:  distance_calcs GetCandidateDistance:  104525667
NOTICE:  distance_calcs CheckElementCloser:     54738005
NOTICE:     cache_hit_a:    3664170
NOTICE:    cache_miss_a:   55696905
NOTICE:     cache_hit_b:     958900
NOTICE:    cache_miss_b:   54738005
NOTICE:     cache_miss:    54738005
```
