### PR TITLE
Offer pre-built `pgvector` releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,7 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && ^
           nmake /NOLOGO /F Makefile.win && ^
           nmake /NOLOGO /F Makefile.win install && ^
-          nmake /NOLOGO /F Makefile.win installcheck
-      - run: |
+          nmake /NOLOGO /F Makefile.win installcheck && ^
           nmake /NOLOGO /F Makefile.win clean && ^
           nmake /NOLOGO /F Makefile.win uninstall
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install libipc-run-perl
       - run: make prove_installcheck
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: my-artifact
+          path: |
+            ./vector.so
+            ./vector.control
+            ./sql/vector--0.6.0.sql
+
   mac:
     runs-on: macos-latest
     if: ${{ !startsWith(github.ref_name, 'windows') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,9 +91,7 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && ^
           nmake /NOLOGO /F Makefile.win && ^
           nmake /NOLOGO /F Makefile.win install && ^
-          nmake /NOLOGO /F Makefile.win installcheck && ^
-          nmake /NOLOGO /F Makefile.win clean && ^
-          nmake /NOLOGO /F Makefile.win uninstall
+          nmake /NOLOGO /F Makefile.win installcheck
         shell: cmd
   i386:
     if: ${{ !startsWith(github.ref_name, 'mac') && !startsWith(github.ref_name, 'windows') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           name: pgvector-14-windows
           path: |
-            ./vector.so
+            ./vector.dll
             ./vector.control
             ./sql/vector--0.6.0.sql
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: my-artifact
+          name: pgvector-${{ matrix.postgres }}-${{ matrix.os }}
           path: |
             ./vector.so
             ./vector.control

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,20 @@ jobs:
           nmake /NOLOGO /F Makefile.win install && ^
           nmake /NOLOGO /F Makefile.win installcheck
         shell: cmd
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pgvector-14-windows
+          path: |
+            ./vector.so
+            ./vector.control
+            ./sql/vector--0.6.0.sql
+
+      - run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && ^
+          nmake /NOLOGO /F Makefile.win clean && ^
+          nmake /NOLOGO /F Makefile.win uninstall
+        shell: cmd
   i386:
     if: ${{ !startsWith(github.ref_name, 'mac') && !startsWith(github.ref_name, 'windows') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,15 +92,6 @@ jobs:
           nmake /NOLOGO /F Makefile.win && ^
           nmake /NOLOGO /F Makefile.win install && ^
           nmake /NOLOGO /F Makefile.win installcheck
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pgvector-14-windows
-          path: |
-            ./vector.so
-            ./vector.control
-            ./sql/vector--0.6.0.sql
-
       - run: |
           nmake /NOLOGO /F Makefile.win clean && ^
           nmake /NOLOGO /F Makefile.win uninstall

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,15 @@ jobs:
       - run: make installcheck
       - if: ${{ failure() }}
         run: cat regression.diffs
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pgvector-14-macos
+          path: |
+            ./vector.so
+            ./vector.control
+            ./sql/vector--0.6.0.sql
+
       - run: |
           brew install cpanm
           cpanm --notest IPC::Run
@@ -82,7 +91,17 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && ^
           nmake /NOLOGO /F Makefile.win && ^
           nmake /NOLOGO /F Makefile.win install && ^
-          nmake /NOLOGO /F Makefile.win installcheck && ^
+          nmake /NOLOGO /F Makefile.win installcheck
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pgvector-14-windows
+          path: |
+            ./vector.so
+            ./vector.control
+            ./sql/vector--0.6.0.sql
+
+      - run: |
           nmake /NOLOGO /F Makefile.win clean && ^
           nmake /NOLOGO /F Makefile.win uninstall
         shell: cmd


### PR DESCRIPTION
First of all, thanks for the great work on `pgvector`.

I have been working on a `pgvector` powered project in the recent past, and one of the problems we encountered was building `pgvector`. We needed only the built files to place into a custom `postgres` installation (that lacked `pg_config`, for example), and even though there are many ways to run `pgvector`, it seemed hard to get just the build files.

I wanted to add a github action that builds `pgvector` for a suitable matrix of `postgres` versions and operating systems. But it turns out that `build.yml` already does that, it just doesn't keep the built files around.

This PR adds the build-artifact github action to `build.yml` jobs.

This is just a simple example, if this direction is approved by the maintainers, we should also add the built files to the proper release. For now, they are available on the actual github action run, as artifacts.