### PR TITLE
Add bulk-loading capability to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ INSERT INTO items (id, embedding) VALUES (1, '[1,2,3]'), (2, '[4,5,6]')
     ON CONFLICT (id) DO UPDATE SET embedding = EXCLUDED.embedding;
 ```
 
+Load vectors in bulk using Postgres `COPY`
+
+```sql
+COPY items (id, embedding) FROM STDIN;
+```
+
 Update vectors
 
 ```sql


### PR DESCRIPTION
Inserting vectors via `INSERT INTO ... VALUES` might be much more expensive. Instead, `COPY` is preferred due to being much faster:

```sql
COPY items (embedding) FROM STDIN
```

![image](https://github.com/pgvector/pgvector/assets/17970732/e73a7b59-36f3-4604-9258-ed24b57b2d7a)

Reference: 
- https://dev.to/josethz00/speed-up-your-postgresql-bulk-inserts-with-copy-40pk
- https://stackoverflow.com/questions/46715354/how-does-copy-work-and-why-is-it-so-much-faster-than-insert