### PR TITLE
Fix compiler warnings in strict C99 mode

### DIFF
--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -129,7 +129,7 @@ HnswPtrDeclare(HnswNeighborArray, HnswNeighborArrayRelptr, HnswNeighborArrayPtr)
 HnswPtrDeclare(HnswNeighborArrayPtr, HnswNeighborsRelptr, HnswNeighborsPtr);
 HnswPtrDeclare(char, DatumRelptr, DatumPtr);
 
-typedef struct HnswElementData
+struct HnswElementData
 {
 	HnswElementPtr next;
 	ItemPointerData heaptids[HNSW_HEAPTIDS];
@@ -144,7 +144,7 @@ typedef struct HnswElementData
 	BlockNumber neighborPage;
 	DatumPtr	value;
 	LWLock		lock;
-}			HnswElementData;
+};
 
 typedef HnswElementData * HnswElement;
 
@@ -155,12 +155,12 @@ typedef struct HnswCandidate
 	bool		closer;
 }			HnswCandidate;
 
-typedef struct HnswNeighborArray
+struct HnswNeighborArray
 {
 	int			length;
 	bool		closerSet;
 	HnswCandidate items[FLEXIBLE_ARRAY_MEMBER];
-}			HnswNeighborArray;
+};
 
 typedef struct HnswPairingHeapNode
 {


### PR DESCRIPTION
Redefining a typedef is a C11 feature:

    In file included from src/hnsw.c:10:
    src/hnsw.h:147:5: warning: redefinition of typedef 'HnswElementData' is a C11 feature [-Wtypedef-redefinition]
    }                       HnswElementData;
                            ^
    src/hnsw.h:118:32: note: previous definition is here
    typedef struct HnswElementData HnswElementData;
                                   ^
    src/hnsw.h:163:5: warning: redefinition of typedef 'HnswNeighborArray' is a C11 feature [-Wtypedef-redefinition]
    }                       HnswNeighborArray;
                            ^
    src/hnsw.h:119:34: note: previous definition is here
    typedef struct HnswNeighborArray HnswNeighborArray;
                                     ^
    2 warnings generated.

I got these warnings when I built PostgreSQL with "CC=clang CFLAGS=-std=gnu99"; other similar options would surely produce the warnings too.