### PR TITLE
Forbid zero values in sparsevec's binary input function

### DIFF
--- a/src/sparsevec.c
+++ b/src/sparsevec.c
@@ -527,6 +527,10 @@ sparsevec_recv(PG_FUNCTION_ARGS)
 	{
 		values[i] = pq_getmsgfloat4(buf);
 		CheckElement(values[i]);
+		if (values[i] == 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATA_EXCEPTION),
+					 errmsg("binary representation of sparsevec cannot contain zero values")));
 	}
 
 	PG_RETURN_POINTER(result);


### PR DESCRIPTION
The text input function simply left out any zero values, but the binary input function did not. That's problematic because you end up with an "unnormalized" sparse vector, which behaves in weird ways.  At least sparsevec_cmp_internal() expects both inputs to not contain zeros.

The binary send function never produces such zero values, but an external tool could. Or to test, you can use COPY TO (FORMAT BINARY), use a hex editor to edit one of the values to be zero, and copy it back with COPY FROM (FORMAT BINARY).