### PR TITLE
Make vector clone targets configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,6 +1026,22 @@ To compile for portability, use:
 make OPTFLAGS=""
 ```
 
+### Optimized Versions of Certain Distance Functions
+
+By default, pgvector uses [function multiversioning][gcc:fmv] for certain distance
+computations to enable [automatic vectorization][wiki:av]. Currently, pgvector
+generates two clones for each of these functions: `default` and `fma`.
+
+To generate different clone targets for these functions (e.g., for `default`, `fma`,
+`avx`, `avx2`, and `avx512f`), use:
+
+```sh
+make OPTFLAGS="" CPPFLAGS='-D VECTOR_TARGET_CLONES_TARGETS=\'"default", "fma", "avx", "avx2", "avx512f"\''
+```
+
+[gcc:fmv]: https://gcc.gnu.org/onlinedocs/gcc/Function-Multiversioning.html
+[wiki:av]: https://en.wikipedia.org/wiki/Automatic_vectorization
+
 ## Installation Notes - Windows
 
 ### Missing Header

--- a/src/vector.c
+++ b/src/vector.c
@@ -35,7 +35,10 @@
 #define CreateStateDatums(dim) palloc(sizeof(Datum) * (dim + 1))
 
 #if defined(USE_TARGET_CLONES) && !defined(__FMA__)
-#define VECTOR_TARGET_CLONES __attribute__((target_clones("default", "fma")))
+#ifndef VECTOR_TARGET_CLONES_TARGETS
+#define VECTOR_TARGET_CLONES_TARGETS "default", "fma"
+#endif
+#define VECTOR_TARGET_CLONES __attribute__((target_clones(VECTOR_TARGET_CLONES_TARGETS)))
 #else
 #define VECTOR_TARGET_CLONES
 #endif


### PR DESCRIPTION
Added a new preprocessor directive to make function multiversioning on distance computations configurable, i.e., during build time, the user can provide `CPPFLAGS` to override the default target clones.

Modified README.md to explain the behavior.

Closes #551.