### PR TITLE
Submit a simple vector dimensionality reduction function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ regression.*
 *.obj
 *.lib
 *.exp
+test/python/*.txt

--- a/sql/vector.sql
+++ b/sql/vector.sql
@@ -782,6 +782,9 @@ CREATE FUNCTION halfvec_to_sparsevec(halfvec, integer, boolean) RETURNS sparseve
 CREATE FUNCTION sparsevec_to_halfvec(sparsevec, integer, boolean) RETURNS halfvec
 	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION vector_norm_reduce(vector, integer) RETURNS vector
+    AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 -- sparsevec casts
 
 CREATE CAST (sparsevec AS sparsevec)

--- a/test/python/ask.py
+++ b/test/python/ask.py
@@ -1,0 +1,56 @@
+'''
+test reduce
+'''
+import json
+import sys
+from sqlalchemy import text, create_engine
+from sqlalchemy.orm import sessionmaker
+import requests
+
+engine = create_engine("postgresql+psycopg2://localhost/pgv")
+ollama_url = "http://localhost:11434/api/embeddings"
+session_maker = sessionmaker(bind=engine)
+
+
+def embedding(segment, model='llama3:8b'):
+    doc = {
+        "model": model,
+        "prompt": segment
+    }
+    resp = requests.post(ollama_url, json=doc)
+    return resp.json()["embedding"]
+
+
+question = sys.argv[1].strip()
+
+vector = embedding(question)
+
+
+def query(session, vector, scale, method):
+    m = f"vector_{method}_reduce"
+    c = method + "_" + str(scale)
+    query = f"select id, {c} <-> {m}(:emb, {scale}), content from items order by {c} <-> {m}(:emb, {scale}) limit 5"
+    return session.execute(text(query), {"emb": json.dumps(vector)}).fetchall()
+
+def print_vs(idx, data, row):
+    print(data[idx][0], row[0], row[1], row[2])
+
+with session_maker() as session:
+    data = []
+    for row in session.execute(text("SELECT id, embedding <-> :emb, content FROM items ORDER BY embedding <-> :emb LIMIT 5;"),
+                               {"emb": json.dumps(vector)}).fetchall():
+        print(row)
+        data.append((row[0], row[1]))
+    print("==============")
+    print(">> integral reduce to 256")
+    for idx, row in enumerate(query(session, vector, 256, 'norm')):
+        print_vs(idx, data, row)
+
+    print(">> integral reduce to 512")
+    for idx, row in enumerate(query(session, vector, 512, 'norm')):
+        print_vs(idx, data, row)
+
+    print(">> integral reduce to 1024")
+    for idx, row in enumerate(query(session, vector, 1024, 'norm')):
+        print_vs(idx, data, row)
+

--- a/test/python/generate_and_save.py
+++ b/test/python/generate_and_save.py
@@ -1,0 +1,75 @@
+'''
+generate test dataset in pg
+
+you need create extension vector at first;
+
+the table is ```
+create table items
+(
+    id            bigserial
+        primary key,
+    content       text,
+    embedding     vector(4096),
+    norm_256  vector(256),
+    norm_512  vector(512),
+    norm_1024 vector(1024)
+);
+```
+
+requirements:
+ * sqlalchemy
+ * psycopg2
+ * requests
+
+$un it as:
+
+```
+python generate_and_save.py xxx.txt
+```
+
+The script will insert content, origin vector and reduced vectors into items table line by line.
+
+'''
+import sys
+
+from sqlalchemy import text, create_engine
+from sqlalchemy.orm import sessionmaker
+import re, json
+import requests
+
+engine = create_engine("postgresql+psycopg2://localhost/pgv")
+
+# doc_path = "/Users/mars/jobs/blue-pro/postgresql-16.1/doc/src/sgml"
+doc = sys.argv[1]
+
+exp = re.compile(r"<para>(.*?)</para>")
+ollama_url = "http://localhost:11434/api/embeddings"
+
+
+def embedding(segment, model='llama3:8b'):
+    doc = {
+        "model": model,
+        "prompt": segment
+    }
+    resp = requests.post(ollama_url, json=doc)
+    return resp.json()["embedding"]
+
+
+session_maker = sessionmaker(bind=engine)
+
+with open(doc) as f, session_maker() as session:
+    for l in f:
+        line=l.strip()
+        if not line:
+            continue
+
+        vector = embedding(line.strip())
+        session.execute(text("insert into items(content, embedding, norm_256, norm_512, norm_1024) "
+                             "select :line, :emb, "
+                             "vector_norm_reduce(:emb, 256), "
+                             "vector_norm_reduce(:emb, 512), "
+                             "vector_norm_reduce(:emb, 1024)"),
+                        {"emb": json.dumps(vector), "line": line})
+        print(line)
+
+    session.commit()


### PR DESCRIPTION
Hello,

I previously submitted a not-so-smart [issue](https://github.com/pgvector/pgvector/pull/402). Thank you everyone for your answers. I have come to understand the index limitations of PG, as well as some other useful knowledge. Particularly, [pgvector: Fewer dimensions are better](https://supabase.com/blog/fewer-dimensions-are-better-pgvector). Based on this article, I decided to tackle the dimensionality issue of ollama from a different angle.

During this period, I have written several dimensionality reduction algorithms. From the perspective of effectiveness and implementation complexity, the simplest method of partitioning and taking the average value is a good choice.

This function is not complicated; on the contrary, among the algorithms I have tried so far, this method is the simplest:

```c
static inline float sum_float(const float *matrix, int start, int stop) {
    float result = 0.0;
    for (int i = start; i < stop; i++) {
        result += matrix[i];
    }
    return result;
}

/*
 * reduce vector dims by norm in fixed ranges
 */
PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_norm_reduce);

Datum
vector_norm_reduce(PG_FUNCTION_ARGS) {
    Vector *vec = PG_GETARG_VECTOR_P(0);
    int32 reduce_to = PG_GETARG_INT32(1);
    Vector *result;
    int dim = vec->dim;
    float *values = vec->x;

    if (reduce_to < 2)
        ereport(ERROR,
                (errcode(ERRCODE_DATA_EXCEPTION),
                        errmsg("vector cannot reduce to a vector less than 2 by shear")));

    if (reduce_to >= dim)
        ereport(ERROR,
                (errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
                        errmsg("vector cannot reduce to more than %d dimensions", dim)));

    CheckDim(dim);
    CheckDim(reduce_to);

    result = InitVector(reduce_to);

    int step = vec->dim / reduce_to;
    for (int idx = 0; idx < reduce_to; idx++) {
        int start = idx * step;
        int stop = (idx + 1) * step - 1;
        if (stop > reduce_to - 1) {
            stop = reduce_to - 1;
        }
        float range = stop - start;
        result->x[idx] = sum_float(vec->x, start, stop) / range;
    }

    PG_RETURN_POINTER(result);
}
```

I have collected hundreds of sentences of text, including both Chinese and English, some technical articles and literary works, and compared the 4096-dimensional embedding vectors generated directly from ollama with the results of different compression methods. The norm algorithm compressed to 512 dimensions achieved the best results, and most of the time its search results are closer to the original 4096-dimensional vectors.

The Python script `test/python/generate_and_save.py` is used to generate test data, for example:
```bash
python test/python/generate_and_save.py test/python/stories.txt
```

Another Python script `test/python/ask.py` is used to compare search results, executed like this:
```bash
python test/python/ask.py "They're playing our song."
```

Perhaps, in addition to me, there may be users who need to generate compressed vectors of lower dimensions from high-dimensional embedding vectors. I hope this function can be of help.