### PR TITLE
Fix init_fork WAL-logging on unlogged table indexes

### DIFF
--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -1121,8 +1121,8 @@ BuildIndex(Relation heap, Relation index, IndexInfo *indexInfo,
 
 	BuildGraph(buildstate, forkNum);
 
-	if (RelationNeedsWAL(index))
-		log_newpage_range(index, forkNum, 0, RelationGetNumberOfBlocks(index), true);
+	if (RelationNeedsWAL(index) || forkNum == INIT_FORKNUM)
+		log_newpage_range(index, forkNum, 0, RelationGetNumberOfBlocksInFork(index, forkNum), true);
 
 	FreeBuildState(buildstate);
 }


### PR DESCRIPTION
Hi @ankane !

I ran into a small issue when testing [lantern](https://github.com/lanterndata/lantern) and saw that pgvector might have the same issue.

Currently pgvector does not create any WAL records for unlogged tables. But Postgres assumes INIT_FORK of unlogged tables is persistent and uses it to reset the table index to its default empty state after a server crash.

This patch makes INIT_FORK of unlogged table WAL-tracked, which ensures an unlogged table is usable after a crash-restart.

Without this patch, any index operation on the unlogged table after a crash-restart would result in another server crash.

To reproduce the issue, you can use the following python script that uses [testgres](https://github.com/postgrespro/testgres)

<details>
<summary>
[Code reproducing hnsw index corruption on unlogged tables]
</summary>

```python
# run pip install testgres
import testgres

import signal
import psutil
import os
import logging

# The line below makes all postgres server logs to be printed
testgres.configure_testgres(use_python_logging=True)
LOGGER = logging.getLogger(__name__)
logging.basicConfig(level = logging.INFO)
# logging.basicConfig(filename='/tmp/testgres.log')

# the utility crash-restarts a node managed by the testgres library
def  crash_pg_node(node):
    # kill all children first, checkpointer in particular, to make sure further checkpoints are not done
    # stop all processes, then kill them
    for s in [signal.SIGSTOP, signal.SIGKILL]:
        for child in psutil.Process(node.pid).children():
            #print cmdline
            os.kill(child.pid, s)
        os.kill(node.pid, s)
    try:
        node.stop()
    except:
        pass

# actual test for reproducing issues related to crash-behaviour of hnsw and ivfflat indexes
with testgres.get_new_node() as node:
    node.init()
    node.append_conf("maintenance_work_mem = '1GB'")
    # node.append_conf("checkpoint_timeout = '100min'")
    # node.append_conf("checkpoint_completion_target = '0.9'")
    # node.append_conf("bgwriter_lru_maxpages = '0.9'")
    # force use of vector index on small tables
    node.append_conf('enable_seqscan = off')
    node.start()
    LOGGER.info(f"done starting primary {node}")

    node.execute('CREATE EXTENSION vector;')

    for indtype in ['hnsw', 'ivfflat']:
        # create an unlogged table and populate it with some data
        node.safe_psql(f"""
        CREATE UNLOGGED TABLE t_{indtype} (id int primary key generated always as identity, v vector(3));
        INSERT INTO t_{indtype}(v) SELECT '[1,2,3]'::vector FROM generate_series(1, 10);
        CREATE INDEX idx_{indtype} ON t_{indtype} USING {indtype} (v vector_l2_ops);
        """)

        # note the file path of the index for easy manual inspection
        LOGGER.info(f"unlogged relaiton t_{indtype} filepath: %s", node.execute(f"SELECT pg_relation_filepath('idx_{indtype}')")[0][0])

        # define vector search lambda
        vector_search = lambda: node.safe_psql(f"""
        -- run vector query
        EXPLAIN SELECT * FROM t_{indtype} ORDER BY v <-> '[1,2,3]'::vector LIMIT 2;
        SELECT * FROM t_{indtype} ORDER BY v <-> '[1,2,3]'::vector LIMIT 2;
        """)

        LOGGER.info(f"vector search result: {vector_search()}")
        LOGGER.info(f"crash-restarting the node")
        crash_pg_node(node)
        node.restart()
        LOGGER.info(f"crash-restarted the node")
        # the line below crashes the database if the unlogged table has hnsw index. This patch fixes the issue
        LOGGER.info(f"vector search result after restrt: {vector_search()}")
```
</details>

You'll see an output similar to this:
<details>
<summary>
[Sample output from the script above, run with pgvector without the patch]
</summary>

```bash
INFO:__main__:done starting primary PostgresNode(name='testgres-3d91a0df-9830-4222-943c-f2b741733a90', port=25593, base_dir='/tmp/tgsn_2cckgvun')
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.166 GMT [4016] LOG:  starting PostgreSQL 15.5 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.166 GMT [4016] LOG:  listening on IPv4 address "127.0.0.1", port 25593
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.167 GMT [4016] LOG:  listening on Unix socket "/tmp/.s.PGSQL.25593"
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.168 GMT [4019] LOG:  database system was shut down at 2024-06-10 23:44:32 GMT
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.169 GMT [4016] LOG:  database system is ready to accept connections
INFO:__main__:unlogged relaiton t_hnsw filepath: base/5/16712
INFO:__main__:vector search result: b"Limit  (cost=8.07..8.90 rows=2 width=44)\n  ->  Index Scan using idx_hnsw on t_hnsw  (cost=8.07..12.20 rows=10 width=44)\n        Order By: (v <-> '[1,2,3]'::vector)\n10|[1,2,3]\n9|[1,2,3]\n"
INFO:__main__:crash-restarting the node
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.266 GMT [4024] LOG:  statement: CREATE EXTENSION vector;
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.292 GMT [4030] LOG:  statement:
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:CREATE UNLOGGED TABLE t_hnsw (id int primary key generated always as identity, v vector(3));
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:INSERT INTO t_hnsw(v) SELECT '[1,2,3]'::vector FROM generate_series(1, 10);
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:CREATE INDEX idx_hnsw ON t_hnsw USING hnsw (v vector_l2_ops);
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.300 GMT [4031] LOG:  statement: SELECT pg_relation_filepath('idx_hnsw')
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.304 GMT [4033] LOG:  statement:
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:-- run vector query
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:EXPLAIN SELECT * FROM t_hnsw ORDER BY v <-> '[1,2,3]'::vector LIMIT 2;
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:SELECT * FROM t_hnsw ORDER BY v <-> '[1,2,3]'::vector LIMIT 2;
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.429 GMT [4043] LOG:  starting PostgreSQL 15.5 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.429 GMT [4043] LOG:  listening on IPv4 address "127.0.0.1", port 25593
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.429 GMT [4043] LOG:  listening on Unix socket "/tmp/.s.PGSQL.25593"
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.430 GMT [4046] LOG:  database system was interrupted; last known up at 2024-06-10 23:44:32 GMT
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.430 GMT [4046] LOG:  database system was not properly shut down; automatic recovery in progress
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.431 GMT [4046] LOG:  redo starts at 0/1493638
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.436 GMT [4046] LOG:  invalid record length at 0/159BBC0: wanted 24, got 0
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.436 GMT [4046] LOG:  redo done at 0/159B418 system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.437 GMT [4044] LOG:  checkpoint starting: end-of-recovery immediate wait
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.439 GMT [4044] LOG:  checkpoint complete: wrote 179 buffers (1.1%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.002 s, sync=0.001 s, total=0.002 s; sync files=0, longest=0.000 s, average=0.000 s; distance=1057 kB, estimate=1057 kB
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.439 GMT [4043] LOG:  database system is ready to accept connections
INFO:__main__:crash-restarted the node
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.526 GMT [4051] LOG:  statement:
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:-- run vector query
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:EXPLAIN SELECT * FROM t_hnsw ORDER BY v <-> '[1,2,3]'::vector LIMIT 2;
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:SELECT * FROM t_hnsw ORDER BY v <-> '[1,2,3]'::vector LIMIT 2;
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:TRAP: FailedAssertion("ItemIdHasStorage(((ItemId) (&((PageHeader) (page))->pd_linp[(element->offno) - 1])))", File: "src/hnswutils.c", Line: 559, PID: 4051)
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(ExceptionalCondition+0x99)[0x55f5ad4fc4d9]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:/usr/local/pgsql/lib/vector.so(HnswLoadElement+0x182)[0x7efc290bc9e4]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:/usr/local/pgsql/lib/vector.so(HnswEntryCandidate+0xc3)[0x7efc290bcc65]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:/usr/local/pgsql/lib/vector.so(+0x17a82)[0x7efc290b6a82]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:/usr/local/pgsql/lib/vector.so(hnswgettuple+0x1de)[0x7efc290b6fd2]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(index_getnext_tid+0x54)[0x55f5ad0d0854]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(index_getnext_slot+0x7b)[0x55f5ad0d0acb]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(+0x35a6b3)[0x55f5ad25a6b3]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(ExecScan+0xfc)[0x55f5ad23cebc]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(+0x35c7e0)[0x55f5ad25c7e0]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(standard_ExecutorRun+0x11a)[0x55f5ad232d8a]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(+0x4cdd4f)[0x55f5ad3cdd4f]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(PortalRun+0x191)[0x55f5ad3cf4a1]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(+0x4cb2cd)[0x55f5ad3cb2cd]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(PostgresMain+0x1752)[0x55f5ad3cce82]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(+0x4376a2)[0x55f5ad3376a2]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(PostmasterMain+0xddb)[0x55f5ad33874b]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(main+0x20f)[0x55f5ad05d4bf]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:/lib/x86_64-linux-gnu/libc.so.6(+0x29d90)[0x7efc321f4d90]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80)[0x7efc321f4e40]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:postgres: postgres postgres 127.0.0.1(55862) SELECT(_start+0x25)[0x55f5ad05d805]
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.530 GMT [4051] WARNING:  in segv handler pid: 4051
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:32.530 GMT [4051] WARNING:  waiting for gdb to connect to 4051
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:37.531 GMT [4051] WARNING:  waiting for gdb to connect to 4051
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:42.532 GMT [4051] WARNING:  waiting for gdb to connect to 4051
INFO:testgres-3d91a0df-9830-4222-943c-f2b741733a90:2024-06-10 23:44:47.533 GMT [4051] WARNING:  waiting for gdb to connect to 4051
```
</details>

Note that the first vector search on the unlogged table completes successfully but the second one crashes the database because of a failed assertion. The root cause is that the meta page of the database was reset to all zeros, since that was the initial value of unlogged tables's `_init` fork file and there was no corresponding WAL to replay the fork to a consistent state.


The fix in the patch only affects `hnsw` indexes.
`ivfflat` indexes have a related problem (reproduced in the test harness above) but it is less clear what the right fix for ivfflat is (Do we keep the same lists? Do we `elog(ERROR)` and ask for reindexing?). So I did not include a patch for that.


