### PR TITLE
Remove redundant PGDLLEXPORT qualifiers.

### DIFF
--- a/src/bitvec.c
+++ b/src/bitvec.c
@@ -40,7 +40,7 @@ CheckDims(VarBit *a, VarBit *b)
 /*
  * Get the Hamming distance between two bit vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(hamming_distance);
+PG_FUNCTION_INFO_V1(hamming_distance);
 Datum
 hamming_distance(PG_FUNCTION_ARGS)
 {
@@ -55,7 +55,7 @@ hamming_distance(PG_FUNCTION_ARGS)
 /*
  * Get the Jaccard distance between two bit vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(jaccard_distance);
+PG_FUNCTION_INFO_V1(jaccard_distance);
 Datum
 jaccard_distance(PG_FUNCTION_ARGS)
 {

--- a/src/halfvec.c
+++ b/src/halfvec.c
@@ -185,7 +185,7 @@ float_underflow_error(void)
 /*
  * Convert textual representation to internal representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_in);
+PG_FUNCTION_INFO_V1(halfvec_in);
 Datum
 halfvec_in(PG_FUNCTION_ARGS)
 {
@@ -299,7 +299,7 @@ halfvec_in(PG_FUNCTION_ARGS)
 /*
  * Convert internal representation to textual representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_out);
+PG_FUNCTION_INFO_V1(halfvec_out);
 Datum
 halfvec_out(PG_FUNCTION_ARGS)
 {
@@ -345,7 +345,7 @@ halfvec_out(PG_FUNCTION_ARGS)
 /*
  * Convert type modifier
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_typmod_in);
+PG_FUNCTION_INFO_V1(halfvec_typmod_in);
 Datum
 halfvec_typmod_in(PG_FUNCTION_ARGS)
 {
@@ -376,7 +376,7 @@ halfvec_typmod_in(PG_FUNCTION_ARGS)
 /*
  * Convert external binary representation to internal representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_recv);
+PG_FUNCTION_INFO_V1(halfvec_recv);
 Datum
 halfvec_recv(PG_FUNCTION_ARGS)
 {
@@ -410,7 +410,7 @@ halfvec_recv(PG_FUNCTION_ARGS)
 /*
  * Convert internal representation to the external binary representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_send);
+PG_FUNCTION_INFO_V1(halfvec_send);
 Datum
 halfvec_send(PG_FUNCTION_ARGS)
 {
@@ -430,7 +430,7 @@ halfvec_send(PG_FUNCTION_ARGS)
  * Convert half vector to half vector
  * This is needed to check the type modifier
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec);
+PG_FUNCTION_INFO_V1(halfvec);
 Datum
 halfvec(PG_FUNCTION_ARGS)
 {
@@ -445,7 +445,7 @@ halfvec(PG_FUNCTION_ARGS)
 /*
  * Convert array to half vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(array_to_halfvec);
+PG_FUNCTION_INFO_V1(array_to_halfvec);
 Datum
 array_to_halfvec(PG_FUNCTION_ARGS)
 {
@@ -519,7 +519,7 @@ array_to_halfvec(PG_FUNCTION_ARGS)
 /*
  * Convert half vector to float4[]
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_to_float4);
+PG_FUNCTION_INFO_V1(halfvec_to_float4);
 Datum
 halfvec_to_float4(PG_FUNCTION_ARGS)
 {
@@ -543,7 +543,7 @@ halfvec_to_float4(PG_FUNCTION_ARGS)
 /*
  * Convert vector to half vec
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_to_halfvec);
+PG_FUNCTION_INFO_V1(vector_to_halfvec);
 Datum
 vector_to_halfvec(PG_FUNCTION_ARGS)
 {
@@ -565,7 +565,7 @@ vector_to_halfvec(PG_FUNCTION_ARGS)
 /*
  * Get the L2 distance between half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_l2_distance);
+PG_FUNCTION_INFO_V1(halfvec_l2_distance);
 Datum
 halfvec_l2_distance(PG_FUNCTION_ARGS)
 {
@@ -580,7 +580,7 @@ halfvec_l2_distance(PG_FUNCTION_ARGS)
 /*
  * Get the L2 squared distance between half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_l2_squared_distance);
+PG_FUNCTION_INFO_V1(halfvec_l2_squared_distance);
 Datum
 halfvec_l2_squared_distance(PG_FUNCTION_ARGS)
 {
@@ -595,7 +595,7 @@ halfvec_l2_squared_distance(PG_FUNCTION_ARGS)
 /*
  * Get the inner product of two half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_inner_product);
+PG_FUNCTION_INFO_V1(halfvec_inner_product);
 Datum
 halfvec_inner_product(PG_FUNCTION_ARGS)
 {
@@ -610,7 +610,7 @@ halfvec_inner_product(PG_FUNCTION_ARGS)
 /*
  * Get the negative inner product of two half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_negative_inner_product);
+PG_FUNCTION_INFO_V1(halfvec_negative_inner_product);
 Datum
 halfvec_negative_inner_product(PG_FUNCTION_ARGS)
 {
@@ -625,7 +625,7 @@ halfvec_negative_inner_product(PG_FUNCTION_ARGS)
 /*
  * Get the cosine distance between two half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_cosine_distance);
+PG_FUNCTION_INFO_V1(halfvec_cosine_distance);
 Datum
 halfvec_cosine_distance(PG_FUNCTION_ARGS)
 {
@@ -657,7 +657,7 @@ halfvec_cosine_distance(PG_FUNCTION_ARGS)
  * Currently uses angular distance since needs to satisfy triangle inequality
  * Assumes inputs are unit vectors (skips norm)
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_spherical_distance);
+PG_FUNCTION_INFO_V1(halfvec_spherical_distance);
 Datum
 halfvec_spherical_distance(PG_FUNCTION_ARGS)
 {
@@ -681,7 +681,7 @@ halfvec_spherical_distance(PG_FUNCTION_ARGS)
 /*
  * Get the L1 distance between two half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_l1_distance);
+PG_FUNCTION_INFO_V1(halfvec_l1_distance);
 Datum
 halfvec_l1_distance(PG_FUNCTION_ARGS)
 {
@@ -696,7 +696,7 @@ halfvec_l1_distance(PG_FUNCTION_ARGS)
 /*
  * Get the dimensions of a half vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_vector_dims);
+PG_FUNCTION_INFO_V1(halfvec_vector_dims);
 Datum
 halfvec_vector_dims(PG_FUNCTION_ARGS)
 {
@@ -708,7 +708,7 @@ halfvec_vector_dims(PG_FUNCTION_ARGS)
 /*
  * Get the L2 norm of a half vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_l2_norm);
+PG_FUNCTION_INFO_V1(halfvec_l2_norm);
 Datum
 halfvec_l2_norm(PG_FUNCTION_ARGS)
 {
@@ -730,7 +730,7 @@ halfvec_l2_norm(PG_FUNCTION_ARGS)
 /*
  * Normalize a half vector with the L2 norm
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_l2_normalize);
+PG_FUNCTION_INFO_V1(halfvec_l2_normalize);
 Datum
 halfvec_l2_normalize(PG_FUNCTION_ARGS)
 {
@@ -769,7 +769,7 @@ halfvec_l2_normalize(PG_FUNCTION_ARGS)
 /*
  * Add half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_add);
+PG_FUNCTION_INFO_V1(halfvec_add);
 Datum
 halfvec_add(PG_FUNCTION_ARGS)
 {
@@ -808,7 +808,7 @@ halfvec_add(PG_FUNCTION_ARGS)
 /*
  * Subtract half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_sub);
+PG_FUNCTION_INFO_V1(halfvec_sub);
 Datum
 halfvec_sub(PG_FUNCTION_ARGS)
 {
@@ -847,7 +847,7 @@ halfvec_sub(PG_FUNCTION_ARGS)
 /*
  * Multiply half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_mul);
+PG_FUNCTION_INFO_V1(halfvec_mul);
 Datum
 halfvec_mul(PG_FUNCTION_ARGS)
 {
@@ -889,7 +889,7 @@ halfvec_mul(PG_FUNCTION_ARGS)
 /*
  * Concatenate half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_concat);
+PG_FUNCTION_INFO_V1(halfvec_concat);
 Datum
 halfvec_concat(PG_FUNCTION_ARGS)
 {
@@ -913,7 +913,7 @@ halfvec_concat(PG_FUNCTION_ARGS)
 /*
  * Quantize a half vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_binary_quantize);
+PG_FUNCTION_INFO_V1(halfvec_binary_quantize);
 Datum
 halfvec_binary_quantize(PG_FUNCTION_ARGS)
 {
@@ -931,7 +931,7 @@ halfvec_binary_quantize(PG_FUNCTION_ARGS)
 /*
  * Get a subvector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_subvector);
+PG_FUNCTION_INFO_V1(halfvec_subvector);
 Datum
 halfvec_subvector(PG_FUNCTION_ARGS)
 {
@@ -1005,7 +1005,7 @@ halfvec_cmp_internal(HalfVector * a, HalfVector * b)
 /*
  * Less than
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_lt);
+PG_FUNCTION_INFO_V1(halfvec_lt);
 Datum
 halfvec_lt(PG_FUNCTION_ARGS)
 {
@@ -1018,7 +1018,7 @@ halfvec_lt(PG_FUNCTION_ARGS)
 /*
  * Less than or equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_le);
+PG_FUNCTION_INFO_V1(halfvec_le);
 Datum
 halfvec_le(PG_FUNCTION_ARGS)
 {
@@ -1031,7 +1031,7 @@ halfvec_le(PG_FUNCTION_ARGS)
 /*
  * Equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_eq);
+PG_FUNCTION_INFO_V1(halfvec_eq);
 Datum
 halfvec_eq(PG_FUNCTION_ARGS)
 {
@@ -1044,7 +1044,7 @@ halfvec_eq(PG_FUNCTION_ARGS)
 /*
  * Not equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_ne);
+PG_FUNCTION_INFO_V1(halfvec_ne);
 Datum
 halfvec_ne(PG_FUNCTION_ARGS)
 {
@@ -1057,7 +1057,7 @@ halfvec_ne(PG_FUNCTION_ARGS)
 /*
  * Greater than or equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_ge);
+PG_FUNCTION_INFO_V1(halfvec_ge);
 Datum
 halfvec_ge(PG_FUNCTION_ARGS)
 {
@@ -1070,7 +1070,7 @@ halfvec_ge(PG_FUNCTION_ARGS)
 /*
  * Greater than
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_gt);
+PG_FUNCTION_INFO_V1(halfvec_gt);
 Datum
 halfvec_gt(PG_FUNCTION_ARGS)
 {
@@ -1083,7 +1083,7 @@ halfvec_gt(PG_FUNCTION_ARGS)
 /*
  * Compare half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_cmp);
+PG_FUNCTION_INFO_V1(halfvec_cmp);
 Datum
 halfvec_cmp(PG_FUNCTION_ARGS)
 {
@@ -1096,7 +1096,7 @@ halfvec_cmp(PG_FUNCTION_ARGS)
 /*
  * Accumulate half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_accum);
+PG_FUNCTION_INFO_V1(halfvec_accum);
 Datum
 halfvec_accum(PG_FUNCTION_ARGS)
 {
@@ -1157,7 +1157,7 @@ halfvec_accum(PG_FUNCTION_ARGS)
 /*
  * Average half vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_avg);
+PG_FUNCTION_INFO_V1(halfvec_avg);
 Datum
 halfvec_avg(PG_FUNCTION_ARGS)
 {
@@ -1191,7 +1191,7 @@ halfvec_avg(PG_FUNCTION_ARGS)
 /*
  * Convert sparse vector to half vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_to_halfvec);
+PG_FUNCTION_INFO_V1(sparsevec_to_halfvec);
 Datum
 sparsevec_to_halfvec(PG_FUNCTION_ARGS)
 {

--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -187,7 +187,7 @@ hnswvalidate(Oid opclassoid)
  *
  * See https://www.postgresql.org/docs/current/index-api.html
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(hnswhandler);
+PG_FUNCTION_INFO_V1(hnswhandler);
 Datum
 hnswhandler(PG_FUNCTION_ARGS)
 {

--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -1270,9 +1270,9 @@ HnswFindElementNeighbors(char *base, HnswElement element, HnswElement entryPoint
 	}
 }
 
-PGDLLEXPORT Datum l2_normalize(PG_FUNCTION_ARGS);
-PGDLLEXPORT Datum halfvec_l2_normalize(PG_FUNCTION_ARGS);
-PGDLLEXPORT Datum sparsevec_l2_normalize(PG_FUNCTION_ARGS);
+Datum l2_normalize(PG_FUNCTION_ARGS);
+Datum halfvec_l2_normalize(PG_FUNCTION_ARGS);
+Datum sparsevec_l2_normalize(PG_FUNCTION_ARGS);
 
 static void
 SparsevecCheckValue(Pointer v)
@@ -1305,7 +1305,7 @@ HnswGetTypeInfo(Relation index)
 		return (const HnswTypeInfo *) DatumGetPointer(FunctionCall0Coll(procinfo, InvalidOid));
 }
 
-PGDLLEXPORT PG_FUNCTION_INFO_V1(hnsw_halfvec_support);
+PG_FUNCTION_INFO_V1(hnsw_halfvec_support);
 Datum
 hnsw_halfvec_support(PG_FUNCTION_ARGS)
 {
@@ -1318,7 +1318,7 @@ hnsw_halfvec_support(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(&typeInfo);
 };
 
-PGDLLEXPORT PG_FUNCTION_INFO_V1(hnsw_bit_support);
+PG_FUNCTION_INFO_V1(hnsw_bit_support);
 Datum
 hnsw_bit_support(PG_FUNCTION_ARGS)
 {
@@ -1331,7 +1331,7 @@ hnsw_bit_support(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(&typeInfo);
 };
 
-PGDLLEXPORT PG_FUNCTION_INFO_V1(hnsw_sparsevec_support);
+PG_FUNCTION_INFO_V1(hnsw_sparsevec_support);
 Datum
 hnsw_sparsevec_support(PG_FUNCTION_ARGS)
 {

--- a/src/ivfflat.c
+++ b/src/ivfflat.c
@@ -181,7 +181,7 @@ ivfflatvalidate(Oid opclassoid)
  *
  * See https://www.postgresql.org/docs/current/index-api.html
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(ivfflathandler);
+PG_FUNCTION_INFO_V1(ivfflathandler);
 Datum
 ivfflathandler(PG_FUNCTION_ARGS)
 {

--- a/src/ivfutils.c
+++ b/src/ivfutils.c
@@ -229,9 +229,9 @@ IvfflatUpdateList(Relation index, ListInfo listInfo,
 	}
 }
 
-PGDLLEXPORT Datum l2_normalize(PG_FUNCTION_ARGS);
-PGDLLEXPORT Datum halfvec_l2_normalize(PG_FUNCTION_ARGS);
-PGDLLEXPORT Datum sparsevec_l2_normalize(PG_FUNCTION_ARGS);
+Datum l2_normalize(PG_FUNCTION_ARGS);
+Datum halfvec_l2_normalize(PG_FUNCTION_ARGS);
+Datum sparsevec_l2_normalize(PG_FUNCTION_ARGS);
 
 static Size
 VectorItemSize(int dimensions)
@@ -342,7 +342,7 @@ IvfflatGetTypeInfo(Relation index)
 		return (const IvfflatTypeInfo *) DatumGetPointer(FunctionCall0Coll(procinfo, InvalidOid));
 }
 
-PGDLLEXPORT PG_FUNCTION_INFO_V1(ivfflat_halfvec_support);
+PG_FUNCTION_INFO_V1(ivfflat_halfvec_support);
 Datum
 ivfflat_halfvec_support(PG_FUNCTION_ARGS)
 {
@@ -357,7 +357,7 @@ ivfflat_halfvec_support(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(&typeInfo);
 };
 
-PGDLLEXPORT PG_FUNCTION_INFO_V1(ivfflat_bit_support);
+PG_FUNCTION_INFO_V1(ivfflat_bit_support);
 Datum
 ivfflat_bit_support(PG_FUNCTION_ARGS)
 {

--- a/src/sparsevec.c
+++ b/src/sparsevec.c
@@ -188,7 +188,7 @@ CompareIndices(const void *a, const void *b)
 /*
  * Convert textual representation to internal representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_in);
+PG_FUNCTION_INFO_V1(sparsevec_in);
 Datum
 sparsevec_in(PG_FUNCTION_ARGS)
 {
@@ -409,7 +409,7 @@ sparsevec_in(PG_FUNCTION_ARGS)
 /*
  * Convert internal representation to textual representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_out);
+PG_FUNCTION_INFO_V1(sparsevec_out);
 Datum
 sparsevec_out(PG_FUNCTION_ARGS)
 {
@@ -462,7 +462,7 @@ sparsevec_out(PG_FUNCTION_ARGS)
 /*
  * Convert type modifier
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_typmod_in);
+PG_FUNCTION_INFO_V1(sparsevec_typmod_in);
 Datum
 sparsevec_typmod_in(PG_FUNCTION_ARGS)
 {
@@ -493,7 +493,7 @@ sparsevec_typmod_in(PG_FUNCTION_ARGS)
 /*
  * Convert external binary representation to internal representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_recv);
+PG_FUNCTION_INFO_V1(sparsevec_recv);
 Datum
 sparsevec_recv(PG_FUNCTION_ARGS)
 {
@@ -545,7 +545,7 @@ sparsevec_recv(PG_FUNCTION_ARGS)
 /*
  * Convert internal representation to the external binary representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_send);
+PG_FUNCTION_INFO_V1(sparsevec_send);
 Datum
 sparsevec_send(PG_FUNCTION_ARGS)
 {
@@ -572,7 +572,7 @@ sparsevec_send(PG_FUNCTION_ARGS)
  * Convert sparse vector to sparse vector
  * This is needed to check the type modifier
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec);
+PG_FUNCTION_INFO_V1(sparsevec);
 Datum
 sparsevec(PG_FUNCTION_ARGS)
 {
@@ -587,7 +587,7 @@ sparsevec(PG_FUNCTION_ARGS)
 /*
  * Convert dense vector to sparse vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_to_sparsevec);
+PG_FUNCTION_INFO_V1(vector_to_sparsevec);
 Datum
 vector_to_sparsevec(PG_FUNCTION_ARGS)
 {
@@ -630,7 +630,7 @@ vector_to_sparsevec(PG_FUNCTION_ARGS)
 /*
  * Convert half vector to sparse vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_to_sparsevec);
+PG_FUNCTION_INFO_V1(halfvec_to_sparsevec);
 Datum
 halfvec_to_sparsevec(PG_FUNCTION_ARGS)
 {
@@ -721,7 +721,7 @@ SparsevecL2SquaredDistance(SparseVector * a, SparseVector * b)
 /*
  * Get the L2 distance between sparse vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_l2_distance);
+PG_FUNCTION_INFO_V1(sparsevec_l2_distance);
 Datum
 sparsevec_l2_distance(PG_FUNCTION_ARGS)
 {
@@ -737,7 +737,7 @@ sparsevec_l2_distance(PG_FUNCTION_ARGS)
  * Get the L2 squared distance between sparse vectors
  * This saves a sqrt calculation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_l2_squared_distance);
+PG_FUNCTION_INFO_V1(sparsevec_l2_squared_distance);
 Datum
 sparsevec_l2_squared_distance(PG_FUNCTION_ARGS)
 {
@@ -788,7 +788,7 @@ SparsevecInnerProduct(SparseVector * a, SparseVector * b)
 /*
  * Get the inner product of two sparse vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_inner_product);
+PG_FUNCTION_INFO_V1(sparsevec_inner_product);
 Datum
 sparsevec_inner_product(PG_FUNCTION_ARGS)
 {
@@ -803,7 +803,7 @@ sparsevec_inner_product(PG_FUNCTION_ARGS)
 /*
  * Get the negative inner product of two sparse vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_negative_inner_product);
+PG_FUNCTION_INFO_V1(sparsevec_negative_inner_product);
 Datum
 sparsevec_negative_inner_product(PG_FUNCTION_ARGS)
 {
@@ -818,7 +818,7 @@ sparsevec_negative_inner_product(PG_FUNCTION_ARGS)
 /*
  * Get the cosine distance between two sparse vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_cosine_distance);
+PG_FUNCTION_INFO_V1(sparsevec_cosine_distance);
 Datum
 sparsevec_cosine_distance(PG_FUNCTION_ARGS)
 {
@@ -863,7 +863,7 @@ sparsevec_cosine_distance(PG_FUNCTION_ARGS)
 /*
  * Get the L1 distance between two sparse vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_l1_distance);
+PG_FUNCTION_INFO_V1(sparsevec_l1_distance);
 Datum
 sparsevec_l1_distance(PG_FUNCTION_ARGS)
 {
@@ -912,7 +912,7 @@ sparsevec_l1_distance(PG_FUNCTION_ARGS)
 /*
  * Get the L2 norm of a sparse vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_l2_norm);
+PG_FUNCTION_INFO_V1(sparsevec_l2_norm);
 Datum
 sparsevec_l2_norm(PG_FUNCTION_ARGS)
 {
@@ -930,7 +930,7 @@ sparsevec_l2_norm(PG_FUNCTION_ARGS)
 /*
  * Normalize a sparse vector with the L2 norm
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_l2_normalize);
+PG_FUNCTION_INFO_V1(sparsevec_l2_normalize);
 Datum
 sparsevec_l2_normalize(PG_FUNCTION_ARGS)
 {
@@ -1040,7 +1040,7 @@ sparsevec_cmp_internal(SparseVector * a, SparseVector * b)
 /*
  * Less than
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_lt);
+PG_FUNCTION_INFO_V1(sparsevec_lt);
 Datum
 sparsevec_lt(PG_FUNCTION_ARGS)
 {
@@ -1053,7 +1053,7 @@ sparsevec_lt(PG_FUNCTION_ARGS)
 /*
  * Less than or equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_le);
+PG_FUNCTION_INFO_V1(sparsevec_le);
 Datum
 sparsevec_le(PG_FUNCTION_ARGS)
 {
@@ -1066,7 +1066,7 @@ sparsevec_le(PG_FUNCTION_ARGS)
 /*
  * Equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_eq);
+PG_FUNCTION_INFO_V1(sparsevec_eq);
 Datum
 sparsevec_eq(PG_FUNCTION_ARGS)
 {
@@ -1079,7 +1079,7 @@ sparsevec_eq(PG_FUNCTION_ARGS)
 /*
  * Not equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_ne);
+PG_FUNCTION_INFO_V1(sparsevec_ne);
 Datum
 sparsevec_ne(PG_FUNCTION_ARGS)
 {
@@ -1092,7 +1092,7 @@ sparsevec_ne(PG_FUNCTION_ARGS)
 /*
  * Greater than or equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_ge);
+PG_FUNCTION_INFO_V1(sparsevec_ge);
 Datum
 sparsevec_ge(PG_FUNCTION_ARGS)
 {
@@ -1105,7 +1105,7 @@ sparsevec_ge(PG_FUNCTION_ARGS)
 /*
  * Greater than
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_gt);
+PG_FUNCTION_INFO_V1(sparsevec_gt);
 Datum
 sparsevec_gt(PG_FUNCTION_ARGS)
 {
@@ -1118,7 +1118,7 @@ sparsevec_gt(PG_FUNCTION_ARGS)
 /*
  * Compare sparse vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_cmp);
+PG_FUNCTION_INFO_V1(sparsevec_cmp);
 Datum
 sparsevec_cmp(PG_FUNCTION_ARGS)
 {

--- a/src/vector.c
+++ b/src/vector.c
@@ -181,7 +181,7 @@ float_underflow_error(void)
 /*
  * Convert textual representation to internal representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_in);
+PG_FUNCTION_INFO_V1(vector_in);
 Datum
 vector_in(PG_FUNCTION_ARGS)
 {
@@ -294,7 +294,7 @@ vector_in(PG_FUNCTION_ARGS)
 /*
  * Convert internal representation to textual representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_out);
+PG_FUNCTION_INFO_V1(vector_out);
 Datum
 vector_out(PG_FUNCTION_ARGS)
 {
@@ -348,7 +348,7 @@ PrintVector(char *msg, Vector * vector)
 /*
  * Convert type modifier
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_typmod_in);
+PG_FUNCTION_INFO_V1(vector_typmod_in);
 Datum
 vector_typmod_in(PG_FUNCTION_ARGS)
 {
@@ -379,7 +379,7 @@ vector_typmod_in(PG_FUNCTION_ARGS)
 /*
  * Convert external binary representation to internal representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_recv);
+PG_FUNCTION_INFO_V1(vector_recv);
 Datum
 vector_recv(PG_FUNCTION_ARGS)
 {
@@ -413,7 +413,7 @@ vector_recv(PG_FUNCTION_ARGS)
 /*
  * Convert internal representation to the external binary representation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_send);
+PG_FUNCTION_INFO_V1(vector_send);
 Datum
 vector_send(PG_FUNCTION_ARGS)
 {
@@ -433,7 +433,7 @@ vector_send(PG_FUNCTION_ARGS)
  * Convert vector to vector
  * This is needed to check the type modifier
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector);
+PG_FUNCTION_INFO_V1(vector);
 Datum
 vector(PG_FUNCTION_ARGS)
 {
@@ -448,7 +448,7 @@ vector(PG_FUNCTION_ARGS)
 /*
  * Convert array to vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(array_to_vector);
+PG_FUNCTION_INFO_V1(array_to_vector);
 Datum
 array_to_vector(PG_FUNCTION_ARGS)
 {
@@ -522,7 +522,7 @@ array_to_vector(PG_FUNCTION_ARGS)
 /*
  * Convert vector to float4[]
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_to_float4);
+PG_FUNCTION_INFO_V1(vector_to_float4);
 Datum
 vector_to_float4(PG_FUNCTION_ARGS)
 {
@@ -546,7 +546,7 @@ vector_to_float4(PG_FUNCTION_ARGS)
 /*
  * Convert half vector to vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(halfvec_to_vector);
+PG_FUNCTION_INFO_V1(halfvec_to_vector);
 Datum
 halfvec_to_vector(PG_FUNCTION_ARGS)
 {
@@ -584,7 +584,7 @@ VectorL2SquaredDistance(int dim, float *ax, float *bx)
 /*
  * Get the L2 distance between vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(l2_distance);
+PG_FUNCTION_INFO_V1(l2_distance);
 Datum
 l2_distance(PG_FUNCTION_ARGS)
 {
@@ -600,7 +600,7 @@ l2_distance(PG_FUNCTION_ARGS)
  * Get the L2 squared distance between vectors
  * This saves a sqrt calculation
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_l2_squared_distance);
+PG_FUNCTION_INFO_V1(vector_l2_squared_distance);
 Datum
 vector_l2_squared_distance(PG_FUNCTION_ARGS)
 {
@@ -627,7 +627,7 @@ VectorInnerProduct(int dim, float *ax, float *bx)
 /*
  * Get the inner product of two vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(inner_product);
+PG_FUNCTION_INFO_V1(inner_product);
 Datum
 inner_product(PG_FUNCTION_ARGS)
 {
@@ -642,7 +642,7 @@ inner_product(PG_FUNCTION_ARGS)
 /*
  * Get the negative inner product of two vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_negative_inner_product);
+PG_FUNCTION_INFO_V1(vector_negative_inner_product);
 Datum
 vector_negative_inner_product(PG_FUNCTION_ARGS)
 {
@@ -676,7 +676,7 @@ VectorCosineSimilarity(int dim, float *ax, float *bx)
 /*
  * Get the cosine distance between two vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(cosine_distance);
+PG_FUNCTION_INFO_V1(cosine_distance);
 Datum
 cosine_distance(PG_FUNCTION_ARGS)
 {
@@ -708,7 +708,7 @@ cosine_distance(PG_FUNCTION_ARGS)
  * Currently uses angular distance since needs to satisfy triangle inequality
  * Assumes inputs are unit vectors (skips norm)
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_spherical_distance);
+PG_FUNCTION_INFO_V1(vector_spherical_distance);
 Datum
 vector_spherical_distance(PG_FUNCTION_ARGS)
 {
@@ -745,7 +745,7 @@ VectorL1Distance(int dim, float *ax, float *bx)
 /*
  * Get the L1 distance between two vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(l1_distance);
+PG_FUNCTION_INFO_V1(l1_distance);
 Datum
 l1_distance(PG_FUNCTION_ARGS)
 {
@@ -760,7 +760,7 @@ l1_distance(PG_FUNCTION_ARGS)
 /*
  * Get the dimensions of a vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_dims);
+PG_FUNCTION_INFO_V1(vector_dims);
 Datum
 vector_dims(PG_FUNCTION_ARGS)
 {
@@ -772,7 +772,7 @@ vector_dims(PG_FUNCTION_ARGS)
 /*
  * Get the L2 norm of a vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_norm);
+PG_FUNCTION_INFO_V1(vector_norm);
 Datum
 vector_norm(PG_FUNCTION_ARGS)
 {
@@ -790,7 +790,7 @@ vector_norm(PG_FUNCTION_ARGS)
 /*
  * Normalize a vector with the L2 norm
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(l2_normalize);
+PG_FUNCTION_INFO_V1(l2_normalize);
 Datum
 l2_normalize(PG_FUNCTION_ARGS)
 {
@@ -829,7 +829,7 @@ l2_normalize(PG_FUNCTION_ARGS)
 /*
  * Add vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_add);
+PG_FUNCTION_INFO_V1(vector_add);
 Datum
 vector_add(PG_FUNCTION_ARGS)
 {
@@ -862,7 +862,7 @@ vector_add(PG_FUNCTION_ARGS)
 /*
  * Subtract vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_sub);
+PG_FUNCTION_INFO_V1(vector_sub);
 Datum
 vector_sub(PG_FUNCTION_ARGS)
 {
@@ -895,7 +895,7 @@ vector_sub(PG_FUNCTION_ARGS)
 /*
  * Multiply vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_mul);
+PG_FUNCTION_INFO_V1(vector_mul);
 Datum
 vector_mul(PG_FUNCTION_ARGS)
 {
@@ -931,7 +931,7 @@ vector_mul(PG_FUNCTION_ARGS)
 /*
  * Concatenate vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_concat);
+PG_FUNCTION_INFO_V1(vector_concat);
 Datum
 vector_concat(PG_FUNCTION_ARGS)
 {
@@ -955,7 +955,7 @@ vector_concat(PG_FUNCTION_ARGS)
 /*
  * Quantize a vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(binary_quantize);
+PG_FUNCTION_INFO_V1(binary_quantize);
 Datum
 binary_quantize(PG_FUNCTION_ARGS)
 {
@@ -973,7 +973,7 @@ binary_quantize(PG_FUNCTION_ARGS)
 /*
  * Get a subvector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(subvector);
+PG_FUNCTION_INFO_V1(subvector);
 Datum
 subvector(PG_FUNCTION_ARGS)
 {
@@ -1047,7 +1047,7 @@ vector_cmp_internal(Vector * a, Vector * b)
 /*
  * Less than
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_lt);
+PG_FUNCTION_INFO_V1(vector_lt);
 Datum
 vector_lt(PG_FUNCTION_ARGS)
 {
@@ -1060,7 +1060,7 @@ vector_lt(PG_FUNCTION_ARGS)
 /*
  * Less than or equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_le);
+PG_FUNCTION_INFO_V1(vector_le);
 Datum
 vector_le(PG_FUNCTION_ARGS)
 {
@@ -1073,7 +1073,7 @@ vector_le(PG_FUNCTION_ARGS)
 /*
  * Equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_eq);
+PG_FUNCTION_INFO_V1(vector_eq);
 Datum
 vector_eq(PG_FUNCTION_ARGS)
 {
@@ -1086,7 +1086,7 @@ vector_eq(PG_FUNCTION_ARGS)
 /*
  * Not equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_ne);
+PG_FUNCTION_INFO_V1(vector_ne);
 Datum
 vector_ne(PG_FUNCTION_ARGS)
 {
@@ -1099,7 +1099,7 @@ vector_ne(PG_FUNCTION_ARGS)
 /*
  * Greater than or equal
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_ge);
+PG_FUNCTION_INFO_V1(vector_ge);
 Datum
 vector_ge(PG_FUNCTION_ARGS)
 {
@@ -1112,7 +1112,7 @@ vector_ge(PG_FUNCTION_ARGS)
 /*
  * Greater than
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_gt);
+PG_FUNCTION_INFO_V1(vector_gt);
 Datum
 vector_gt(PG_FUNCTION_ARGS)
 {
@@ -1125,7 +1125,7 @@ vector_gt(PG_FUNCTION_ARGS)
 /*
  * Compare vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_cmp);
+PG_FUNCTION_INFO_V1(vector_cmp);
 Datum
 vector_cmp(PG_FUNCTION_ARGS)
 {
@@ -1138,7 +1138,7 @@ vector_cmp(PG_FUNCTION_ARGS)
 /*
  * Accumulate vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_accum);
+PG_FUNCTION_INFO_V1(vector_accum);
 Datum
 vector_accum(PG_FUNCTION_ARGS)
 {
@@ -1199,7 +1199,7 @@ vector_accum(PG_FUNCTION_ARGS)
 /*
  * Combine vectors or half vectors (also used for halfvec_combine)
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_combine);
+PG_FUNCTION_INFO_V1(vector_combine);
 Datum
 vector_combine(PG_FUNCTION_ARGS)
 {
@@ -1270,7 +1270,7 @@ vector_combine(PG_FUNCTION_ARGS)
 /*
  * Average vectors
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(vector_avg);
+PG_FUNCTION_INFO_V1(vector_avg);
 Datum
 vector_avg(PG_FUNCTION_ARGS)
 {
@@ -1304,7 +1304,7 @@ vector_avg(PG_FUNCTION_ARGS)
 /*
  * Convert sparse vector to dense vector
  */
-PGDLLEXPORT PG_FUNCTION_INFO_V1(sparsevec_to_vector);
+PG_FUNCTION_INFO_V1(sparsevec_to_vector);
 Datum
 sparsevec_to_vector(PG_FUNCTION_ARGS)
 {


### PR DESCRIPTION
For functions being declared with PG_FUNCTION_INFO_V1(), the macro has added the PGDLLEXPORT qualifier automatically[^1].  We don't need to add them manually.

[^1]: https://github.com/postgres/postgres/commit/8cf64d35eaccab967c51d8bccf2c1babe3f84715