### PR TITLE
Add a compiler flag to use 512-bit vector instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ REGRESS_OPTS = --inputdir=test --load-extension=$(EXTENSION)
 
 # To compile for portability, run: make OPTFLAGS=""
 OPTFLAGS = -march=native
+ifeq ($(shell uname -m), x86_64)
+        ifeq ($(USE_512BIT_VECTORS), 1)
+            OPTFLAGS += -mprefer-vector-width=512
+        endif
+endif
 
 # Mac ARM doesn't always support -march=native
 ifeq ($(shell uname -s), Darwin)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd pgvector
 make
 make install # may need sudo
 ```
-
+Set USE_512BIT_VECTORS=1 when running make to instruct the compiler to use 512-bit registers/instructions in auto-vectorized code (e.g., for distance functions).
 See the [installation notes](#installation-notes---linux-and-mac) if you run into issues
 
 You can also install it with [Docker](#docker), [Homebrew](#homebrew), [PGXN](#pgxn), [APT](#apt), [Yum](#yum), [pkg](#pkg), or [conda-forge](#conda-forge), and it comes preinstalled with [Postgres.app](#postgresapp) and many [hosted providers](#hosted-postgres). There are also instructions for [GitHub Actions](https://github.com/pgvector/setup-pgvector).


### PR DESCRIPTION
This PR adds a compiler flag to use 512-bit instructions in auto-vectorized code (-mprefer-vector-width=512).

- Adding the flag is optional and controlled by a variable. To add the flag, set `USE_512BIT_VECTOR=1` when running make. By default, the flag is not added and the existing behavior is unchanged.
- Without this flag, we observe that several compilers (gcc11/12, clang13/14/15) use 256-bit registers even on newer platforms (such as AWS m7i instances). This is observed, for example, in distance functions.
- We observe performance benefits in certain conditions (platform/dataset) by adding this flag. For example, using ANN benchmarks with the gist-960 dataset, we observe 5% qps increase on m7i instances with the flag vs without.
- Note that `-mprefer-vector-width=512` is already used by default in [ANN benchmarks](https://github.com/erikbern/ann-benchmarks/blob/main/ann_benchmarks/algorithms/pgvector/Dockerfile) when building pgvector.