### PR TITLE
[src/hnswutils.c] Resolve 1 `-Wmaybe-uninitialized`

### DIFF
--- a/src/hnswutils.c
+++ b/src/hnswutils.c
@@ -730,7 +730,7 @@ HnswSearchLayer(char *base, Datum q, List *ep, int ef, int lc, Relation index, F
 	visited_hash v;
 	ListCell   *lc2;
 	HnswNeighborArray *neighborhoodData = NULL;
-	Size		neighborhoodSize;
+	Size		neighborhoodSize = 0;
 
 	InitVisited(base, &v, index, ef, m);
 


### PR DESCRIPTION
```
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -O2  -ftree-vectorize -fassociative-math -fno-signed-zeros -fno-trapping-math -fPIC -fvisibility=hidden -I. -I./ -I/usr/local/include/postgresql/server -I/usr/local/include/postgresql/internal  -D_GNU_SOURCE -I/usr/include/libxml2   -c -o src/hnswutils.o src/hnswutils.c
In file included from /usr/local/include/postgresql/server/c.h:61,
                 from /usr/local/include/postgresql/server/postgres.h:45,
                 from src/hnswutils.c:1:
In function 'memcpy',
    inlined from 'HnswSearchLayer' at src/hnswutils.c:786:4:
/usr/include/fortify/string.h:51:31: warning: 'neighborhoodSize' may be used uninitialized [-Wmaybe-uninitialized]
   51 |             (__s < __d && __s + __n > __d))
      |                           ~~~~^~~~~
src/hnswutils.c: In function 'HnswSearchLayer':
src/hnswutils.c:733:25: note: 'neighborhoodSize' was declared here
  733 |         Size            neighborhoodSize;
      |                         ^~~~~~~~~~~~~~~~
```