### PR TITLE
Swap max costing values to align with upstream guidance

### DIFF
--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -9,6 +9,7 @@
 #include "commands/vacuum.h"
 #include "hnsw.h"
 #include "miscadmin.h"
+#include "utils/float.h"
 #include "utils/guc.h"
 #include "utils/selfuncs.h"
 
@@ -112,8 +113,8 @@ hnswcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 	/* Never use index without order */
 	if (path->indexorderbys == NULL)
 	{
-		*indexStartupCost = DBL_MAX;
-		*indexTotalCost = DBL_MAX;
+		*indexStartupCost = get_float8_infinity();
+		*indexTotalCost = get_float8_infinity();
 		*indexSelectivity = 0;
 		*indexCorrelation = 0;
 		*indexPages = 0;

--- a/src/ivfflat.c
+++ b/src/ivfflat.c
@@ -7,6 +7,7 @@
 #include "commands/progress.h"
 #include "commands/vacuum.h"
 #include "ivfflat.h"
+#include "utils/float.h"
 #include "utils/guc.h"
 #include "utils/selfuncs.h"
 #include "utils/spccache.h"
@@ -78,8 +79,8 @@ ivfflatcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 	/* Never use index without order */
 	if (path->indexorderbys == NULL)
 	{
-		*indexStartupCost = DBL_MAX;
-		*indexTotalCost = DBL_MAX;
+		*indexStartupCost = get_float8_infinity();
+		*indexTotalCost = get_float8_infinity();
 		*indexSelectivity = 0;
 		*indexCorrelation = 0;
 		*indexPages = 0;


### PR DESCRIPTION
A feature targeted for PostgreSQL 18 (postgres/postgres@e2225346) that makes optimizations around disabled path nodes impacted pgvector such that PostgreSQL would choose to perform an index scan when it should have used a different scan (e.g. `SELECT count(*) FROM table`). Per upstream guidance[1], the recommendation is to switch to using `get_float8_infinity()`, which achieves the same behavior in backbranches, and can be adapated to work with the new behavior introduced in PostgreSQL 18.

[1] https://www.postgresql.org/message-id/2281822.1724441531%40sss.pgh.pa.us