### PR TITLE
HNSW index test for insert to empty table with empty index is added

### DIFF
--- a/test/expected/hnsw_vector.out
+++ b/test/expected/hnsw_vector.out
@@ -31,6 +31,18 @@ SELECT * FROM t ORDER BY val <-> '[3,3,3]';
 -----
 (0 rows)
 
+-- insert to empty table and empty index
+INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
+INSERT INTO t (val) VALUES ('[1,2,4]');
+SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+   val   
+---------
+ [1,2,3]
+ [1,2,4]
+ [1,1,1]
+ [0,0,0]
+(4 rows)
+
 DROP TABLE t;
 -- inner product
 CREATE TABLE t (val vector(3));

--- a/test/sql/hnsw_vector.sql
+++ b/test/sql/hnsw_vector.sql
@@ -15,6 +15,11 @@ SELECT COUNT(*) FROM t;
 TRUNCATE t;
 SELECT * FROM t ORDER BY val <-> '[3,3,3]';
 
+-- insert to empty table and empty index
+INSERT INTO t (val) VALUES ('[0,0,0]'), ('[1,2,3]'), ('[1,1,1]'), (NULL);
+INSERT INTO t (val) VALUES ('[1,2,4]');
+SELECT * FROM t ORDER BY val <-> '[3,3,3]';
+
 DROP TABLE t;
 
 -- inner product


### PR DESCRIPTION
As soon as TRUNCATE TABLE test is added to check creation of index on empty table, it would be good to add the test of inserting first row to empty table with created index (no one other tests cover this situation). 