### PR TITLE
Fix sparsevec Documentation: Correct Max Non-Zero Elements Limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Supported types are:
 - `vector` - up to 2,000 dimensions
 - `halfvec` - up to 4,000 dimensions (added in 0.7.0)
 - `bit` - up to 64,000 dimensions (added in 0.7.0)
-- `sparsevec` - up to 1,000 non-zero elements (added in 0.7.0)
+- `sparsevec` - up to 16,000 non-zero elements (added in 0.7.0)
 
 ### Index Options
 


### PR DESCRIPTION
This update corrects the maximum number of non-zero elements for the sparsevec data type in the README documentation for pgvector. Previously, the documentation incorrectly stated a limit of "up to 1,000 non-zero elements." The corrected version reflects the actual limit enforced by the code, which allows "up to 16,000 non-zero elements."

Definition of SPARSEVEC_MAX_NNZ:
[#define SPARSEVEC_MAX_NNZ 16000](https://github.com/pgvector/pgvector/blob/master/src/sparsevec.h#L5)

This change ensures consistency between the documentation and the implementation, providing accurate information to users.