### PR TITLE
Avoid -march=native when reproducible build is wanted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test --load-extension=$(EXTENSION)
 
 # To compile for portability, run: make OPTFLAGS=""
-OPTFLAGS = -march=native
+ifdef SOURCE_DATE_EPOCH
+	OPTFLAGS =
+else
+	OPTFLAGS = -march=native
+endif
 
 # Mac ARM doesn't always support -march=native
 ifeq ($(shell uname -s), Darwin)


### PR DESCRIPTION
With this patch, compilation will avoid `-march=native` when a reproducible build is wanted.

See https://reproducible-builds.org/ for why this is good.

Without this patch, compiling on different machines produced different binaries, which made verification of results difficult.

This patch was done while working on reproducible builds for openSUSE.