### PR TITLE
Functions to estimate the amount of memory for building an HNSW index

### DIFF
--- a/sql/vector.sql
+++ b/sql/vector.sql
@@ -916,3 +916,11 @@ CREATE OPERATOR CLASS sparsevec_l1_ops
 	OPERATOR 1 <+> (sparsevec, sparsevec) FOR ORDER BY float_ops,
 	FUNCTION 1 l1_distance(sparsevec, sparsevec),
 	FUNCTION 3 hnsw_sparsevec_support(internal);
+
+CREATE FUNCTION hnsw_build_memory_bytes_per_vector(integer, integer)
+	RETURNS float8
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION hnsw_build_memory_bytes_per_halfvec(integer, integer)
+	RETURNS float8
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;


### PR DESCRIPTION
This will allow users to verify if they can build an HNSW index fully in memory, which is frequently necessary to avoid unacceptable performance degradation, and to compute the appropriate value of maintenance_work_mem.

I am planning to expand this pull request with validation that the estimated memory usage is indeed correct during index build.

Fixes: #745

Related issues: #500
