### PR TITLE
Change NOTICE to WARNING when HNSW graph does not fit in memory during build

### DIFF
--- a/src/hnswbuild.c
+++ b/src/hnswbuild.c
@@ -519,7 +519,7 @@ InsertTuple(Relation index, Datum *values, bool *isnull, ItemPointer heaptid, Hn
 
 		if (!graph->flushed)
 		{
-			ereport(NOTICE,
+			ereport(WARNING,
 					(errmsg("hnsw graph no longer fits into maintenance_work_mem after " INT64_FORMAT " tuples", (int64) graph->indtuples),
 					 errdetail("Building will take significantly more time."),
 					 errhint("Increase maintenance_work_mem to speed up builds.")));


### PR DESCRIPTION
This should help prevent cases where users wait for a very long time (24+ hours) for index build because they have not configured the maintenance work memory correctly, as happened in #300 and #504.