### PR TITLE
Pgvector crossproduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,6 +963,7 @@ Operator | Description | Added
 <#> | negative inner product |
 <=> | cosine distance |
 <+> | taxicab distance | 0.7.0
+<*> | cross product | 0.8.0
 
 ### Vector Functions
 
@@ -977,6 +978,7 @@ l2_normalize(vector) → vector | Normalize with Euclidean norm | 0.7.0
 subvector(vector, integer, integer) → vector | subvector | 0.7.0
 vector_dims(vector) → integer | number of dimensions |
 vector_norm(vector) → double precision | Euclidean norm |
+vector_cross_product(vector,vector) → vector | Cross Product right-handed | 0.8.0
 
 ### Vector Aggregate Functions
 

--- a/sql/vector.sql
+++ b/sql/vector.sql
@@ -111,6 +111,9 @@ CREATE FUNCTION vector_avg(double precision[]) RETURNS vector
 CREATE FUNCTION vector_combine(double precision[], double precision[]) RETURNS double precision[]
 	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION vector_cross_product(vector, vector ) RETURNS vector
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 -- vector aggregates
 
 CREATE AGGREGATE avg(vector) (
@@ -179,6 +182,11 @@ CREATE OPERATOR <-> (
 CREATE OPERATOR <#> (
 	LEFTARG = vector, RIGHTARG = vector, PROCEDURE = vector_negative_inner_product,
 	COMMUTATOR = '<#>'
+);
+
+CREATE OPERATOR <*> (
+    LEFTARG = vector, RIGHTARG = vector, PROCEDURE = vector_cross_product,
+    COMMUTATOR = '<*>'
 );
 
 CREATE OPERATOR <=> (

--- a/test/expected/vector_type.out
+++ b/test/expected/vector_type.out
@@ -670,3 +670,21 @@ SELECT sum(v) FROM unnest(ARRAY['[1,2]'::vector, '[3]']) v;
 ERROR:  different vector dimensions 2 and 1
 SELECT sum(v) FROM unnest(ARRAY['[3e38]'::vector, '[3e38]']) v;
 ERROR:  value out of range: overflow
+
+SELECT vector_cross_product('[1,0,0]'::vector, '[0,1,0]'::vector);
+ vector_cross_product 
+----------------------
+ [0,0,1]
+(1 row)
+
+SELECT vector_cross_product('[1,0,0]'::vector, '[0,0,1]'::vector);
+ vector_cross_product 
+----------------------
+ [0,-1,0]
+(1 row)
+
+SELECT vector_cross_product('[3,-3,1]'::vector, '[4,9,2]'::vector);
+ vector_cross_product 
+----------------------
+ [-15,-2,39]
+(1 row)

--- a/test/expected/vector_type.out
+++ b/test/expected/vector_type.out
@@ -670,7 +670,6 @@ SELECT sum(v) FROM unnest(ARRAY['[1,2]'::vector, '[3]']) v;
 ERROR:  different vector dimensions 2 and 1
 SELECT sum(v) FROM unnest(ARRAY['[3e38]'::vector, '[3e38]']) v;
 ERROR:  value out of range: overflow
-
 SELECT vector_cross_product('[1,0,0]'::vector, '[0,1,0]'::vector);
  vector_cross_product 
 ----------------------
@@ -688,3 +687,4 @@ SELECT vector_cross_product('[3,-3,1]'::vector, '[4,9,2]'::vector);
 ----------------------
  [-15,-2,39]
 (1 row)
+

--- a/test/sql/vector_type.sql
+++ b/test/sql/vector_type.sql
@@ -152,3 +152,7 @@ SELECT sum(v) FROM unnest(ARRAY['[1,2,3]'::vector, '[3,5,7]', NULL]) v;
 SELECT sum(v) FROM unnest(ARRAY[]::vector[]) v;
 SELECT sum(v) FROM unnest(ARRAY['[1,2]'::vector, '[3]']) v;
 SELECT sum(v) FROM unnest(ARRAY['[3e38]'::vector, '[3e38]']) v;
+
+SELECT vector_cross_product('[1,0,0]'::vector, '[0,1,0]'::vector);
+SELECT vector_cross_product('[1,0,0]'::vector, '[0,0,1]'::vector);
+SELECT vector_cross_product('[3,-3,1]'::vector, '[4,9,2]'::vector);


### PR DESCRIPTION
Hello, this is a simple feature: cross product for 3 dimensional vectors, but it is useful for some physics and math calculations .

I have add this function : vector_cross_product (vector,vector) → vector | Cross Product right-handed | 0.8.0  
with the operator symbol <*>

It check if the vectors are the same dimensions and the dimension is 3, the calculate the new vector, then check it there are some overflows and if it's all correct, it returns the result vector. 

I have done some testing and it seems to work correctly