### PR TITLE
increase maximum dimension size for HNSW index

### DIFF
--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -12,7 +12,7 @@
 #include "utils/sampling.h"
 #include "vector.h"
 
-#define HNSW_MAX_DIM 2000
+#define HNSW_MAX_DIM 4000
 #define HNSW_MAX_NNZ 1000
 
 /* Support functions */


### PR DESCRIPTION
Some popular embedding models, such as OpenAI's `text-embedding-3-large` have more than 2,000 dimensions. 
I propose increasing the `HNSW_MAX_DIM` from 2,000 to 4,000 to support larger embedding models. 
