### PR TITLE
Using NEON (if available) for calculating l2_distance and inner_product

### DIFF
--- a/src/vector.c
+++ b/src/vector.c
@@ -21,6 +21,7 @@
 #include "utils/lsyscache.h"
 #include "utils/numeric.h"
 #include "vector.h"
+#include "vector_simd.h"
 
 #if PG_VERSION_NUM >= 160000
 #include "varatt.h"
@@ -545,6 +546,11 @@ halfvec_to_vector(PG_FUNCTION_ARGS)
 VECTOR_TARGET_CLONES static float
 VectorL2SquaredDistance(int dim, float *ax, float *bx)
 {
+#if defined(__ARM_NEON)
+    return VectorL2SquaredDistanceNEON(dim, ax, bx);
+#else
+	// Fall back to simple implementation that does not use any CPU-specific SIMD
+	// instructions.
 	float		distance = 0.0;
 
 	/* Auto-vectorized */
@@ -556,6 +562,7 @@ VectorL2SquaredDistance(int dim, float *ax, float *bx)
 	}
 
 	return distance;
+#endif
 }
 
 /*
@@ -592,6 +599,9 @@ vector_l2_squared_distance(PG_FUNCTION_ARGS)
 VECTOR_TARGET_CLONES static float
 VectorInnerProduct(int dim, float *ax, float *bx)
 {
+#if defined(__ARM_NEON)
+    return VectorInnerProductNEON(dim, ax, bx);
+#else
 	float		distance = 0.0;
 
 	/* Auto-vectorized */
@@ -599,6 +609,8 @@ VectorInnerProduct(int dim, float *ax, float *bx)
 		distance += ax[i] * bx[i];
 
 	return distance;
+
+#endif
 }
 
 /*

--- a/src/vector_simd.h
+++ b/src/vector_simd.h
@@ -1,0 +1,89 @@
+#ifndef VECTOR_SIMD_H
+#define VECTOR_SIMD_H
+
+#include "postgres.h"
+#include "vector.h"
+
+#if defined(__ARM_NEON)
+#include <arm_neon.h>
+
+static inline float
+VectorL2SquaredDistanceNEON(int dim, float *ax, float *bx)
+{
+    float32x4_t sum1 = vdupq_n_f32(0.0f);
+    float32x4_t sum2 = vdupq_n_f32(0.0f);
+    float32x4_t sum3 = vdupq_n_f32(0.0f);
+    float32x4_t sum4 = vdupq_n_f32(0.0f);
+    float32x4_t a1, a2, a3, a4;
+    float32x4_t b1, b2, b3, b4;
+    float32x4_t diff1, diff2, diff3, diff4;
+    float32x2_t sum_lo, sum_hi, sum_half;
+    float neon_sum, remaining_sum;
+    int i = 0;
+
+    for (; i < dim - 15; i += 16) {
+        a1 = vld1q_f32(&ax[i]);
+        b1 = vld1q_f32(&bx[i]);
+        diff1 = vsubq_f32(a1, b1);
+        sum1 = vaddq_f32(sum1, vmulq_f32(diff1, diff1));
+
+        a2 = vld1q_f32(&ax[i + 4]);
+        b2 = vld1q_f32(&bx[i + 4]);
+        diff2 = vsubq_f32(a2, b2);
+        sum2 = vaddq_f32(sum2, vmulq_f32(diff2, diff2));
+
+        a3 = vld1q_f32(&ax[i + 8]);
+        b3 = vld1q_f32(&bx[i + 8]);
+        diff3 = vsubq_f32(a3, b3);
+        sum3 = vaddq_f32(sum3, vmulq_f32(diff3, diff3));
+
+        a4 = vld1q_f32(&ax[i + 12]);
+        b4 = vld1q_f32(&bx[i + 12]);
+        diff4 = vsubq_f32(a4, b4);
+        sum4 = vaddq_f32(sum4, vmulq_f32(diff4, diff4));
+    }
+
+    sum1 = vaddq_f32(sum1, sum2);
+    sum1 = vaddq_f32(sum1, sum3);
+    sum1 = vaddq_f32(sum1, sum4);
+
+    remaining_sum = 0.0f;
+    for (; i < dim; i++) {
+        float diff = ax[i] - bx[i];
+        remaining_sum += diff * diff;
+    }
+
+    sum_lo = vget_low_f32(sum1);
+    sum_hi = vget_high_f32(sum1);
+    sum_half = vadd_f32(sum_lo, sum_hi);
+    neon_sum = vget_lane_f32(vpadd_f32(sum_half, sum_half), 0);
+
+    return neon_sum + remaining_sum;
+}
+
+static inline float
+VectorInnerProductNEON(int dim, float *ax, float *bx)
+{
+    float32x4_t sum = vdupq_n_f32(0.0f);
+    float32x4_t a, b;
+    float32x2_t sum2;
+    float neon_sum, remaining_sum;
+    int i = 0;
+
+    for (; i < dim - 3; i += 4) {
+        a = vld1q_f32(&ax[i]);
+        b = vld1q_f32(&bx[i]);
+        sum = vaddq_f32(sum, vmulq_f32(a, b));
+    }
+
+    remaining_sum = 0.0f;
+    for (; i < dim; i++) {
+        remaining_sum += ax[i] * bx[i];
+    }
+
+    sum2 = vadd_f32(vget_low_f32(sum), vget_high_f32(sum));
+    neon_sum = vget_lane_f32(vpadd_f32(sum2, sum2), 0);
+    return neon_sum + remaining_sum;
+}
+#endif /* __ARM_NEON */
+#endif /* VECTOR_SIMD_H */


### PR DESCRIPTION
This commit adds support for the NEON SIMB extension. This extension is a bit older but it is supported by all current AWS Gravaton chips. Gravaton 3 and Gravaton 4 support SVE and SVE 2 respectively but this commit should still offer a sizable performance improvement across the board.
    
Early testing (on a Macbook Pro) has shown a roughly 8x performance improvement at the cost of no more than 0.0005% precision. This is a result of the order in how floating point values are calculated and it seemed like a reasonable tradeoff for the increased performance.

```
Verifying implementations...
Verification passed!

Benchmark Results:
-----------------
Vector dimension: 1536
Number of vectors: 10000
Number of iterations: 1000

NEON Implementation:
  Total time: 796.31 ms
  Average time per vector: 0.080 us
  Total distance sum: 10238041088.000000

Simple Implementation:
  Total time: 6906.05 ms
  Average time per vector: 0.691 us
  Total distance sum: 10238041088.000000

Speedup: 8.67x
```