### PR TITLE
vectorize: optimize VectorSumCenter and HalfvecSumCenter

### DIFF
--- a/src/ivfutils.c
+++ b/src/ivfutils.c
@@ -295,8 +295,10 @@ static void
 VectorSumCenter(Pointer v, float *x)
 {
 	Vector	   *vec = (Vector *) v;
+	const int dim = vec->dim;
 
-	for (int k = 0; k < vec->dim; k++)
+	/* Auto-vectorized */
+	for (int k = 0; k < dim; k++)
 		x[k] += vec->x[k];
 }
 
@@ -304,8 +306,10 @@ static void
 HalfvecSumCenter(Pointer v, float *x)
 {
 	HalfVector *vec = (HalfVector *) v;
+	const int dim = vec->dim;
 
-	for (int k = 0; k < vec->dim; k++)
+	/* Auto-vectorized */
+	for (int k = 0; k < dim; k++)
 		x[k] += HalfToFloat4(vec->x[k]);
 }
 

--- a/src/ivfutils.c
+++ b/src/ivfutils.c
@@ -295,7 +295,7 @@ static void
 VectorSumCenter(Pointer v, float *x)
 {
 	Vector	   *vec = (Vector *) v;
-	const int dim = vec->dim;
+	int dim = vec->dim;
 
 	/* Auto-vectorized */
 	for (int k = 0; k < dim; k++)
@@ -306,9 +306,9 @@ static void
 HalfvecSumCenter(Pointer v, float *x)
 {
 	HalfVector *vec = (HalfVector *) v;
-	const int dim = vec->dim;
+	int dim = vec->dim;
 
-	/* Auto-vectorized */
+	/* Auto-vectorized on aarch64 */
 	for (int k = 0; k < dim; k++)
 		x[k] += HalfToFloat4(vec->x[k]);
 }


### PR DESCRIPTION
The functions `VectorSumCenter` and `HalfvecSumCenter` were not being vectorized by the compiler. A few slight changes will allow these optimizations to take place and get a performance boost by utilizing SIMD instructions.

This optimization helps improve performance of vector operations in IVF index building and updating.

Verified that the loops are being vectorized by checking `PG_CFLAGS += -Rpass=loop-vectorize -Rpass-analysis=loop-vectorize`.

### Before

```
src/ivfutils.c:262:2: remark: vectorized loop (vectorization width: 4, interleaved count: 4) [-Rpass=loop-vectorize]
  262 |         for (int k = 0; k < dimensions; k++)
      |         ^
src/ivfutils.c:299:2: remark: loop not vectorized: could not determine number of loop iterations [-Rpass-analysis=loop-vectorize]
  299 |         for (int k = 0; k < vec->dim; k++)
      |         ^
src/ivfutils.c:274:2: remark: vectorized loop (vectorization width: 8, interleaved count: 4) [-Rpass=loop-vectorize]
  274 |         for (int k = 0; k < dimensions; k++)
      |         ^
src/ivfutils.c:308:2: remark: loop not vectorized: could not determine number of loop iterations [-Rpass-analysis=loop-vectorize]
  308 |         for (int k = 0; k < vec->dim; k++)
      |         ^
src/ivfutils.c:287:2: remark: vectorized loop (vectorization width: 16, interleaved count: 4) [-Rpass=loop-vectorize]
  287 |         for (uint32 k = 0; k < VARBITBYTES(vec); k++)
      |         ^
src/ivfutils.c:291:3: remark: loop not vectorized: cannot identify array bounds [-Rpass-analysis=loop-vectorize]
  291 |                 nx[k / 8] |= (x[k] > 0.5 ? 1 : 0) << (7 - (k % 8));
      |                 ^
src/ivfutils.c:318:22: remark: loop not vectorized: cannot identify array bounds [-Rpass-analysis=loop-vectorize]
  318 |                 x[k] += (float) (((VARBITS(vec)[k / 8]) >> (7 - (k % 8))) & 0x01);
      |                                    ^
src/ivfutils.c:317:2: remark: loop not vectorized: could not determine number of loop iterations [-Rpass-analysis=loop-vectorize]
  317 |         for (int k = 0; k < VARBITLEN(vec); k++)
      |   
```

### After

```
src/ivfutils.c:262:2: remark: vectorized loop (vectorization width: 4, interleaved count: 4) [-Rpass=loop-vectorize]
  262 |         for (int k = 0; k < dimensions; k++)
      |         ^
src/ivfutils.c:301:2: remark: vectorized loop (vectorization width: 4, interleaved count: 4) [-Rpass=loop-vectorize]
  301 |         for (int k = 0; k < dim; k++)
      |         ^
src/ivfutils.c:274:2: remark: vectorized loop (vectorization width: 8, interleaved count: 4) [-Rpass=loop-vectorize]
  274 |         for (int k = 0; k < dimensions; k++)
      |         ^
src/ivfutils.c:312:2: remark: vectorized loop (vectorization width: 8, interleaved count: 4) [-Rpass=loop-vectorize]
  312 |         for (int k = 0; k < dim; k++)
      |         ^
In file included from src/ivfutils.c:7:
src/halfutils.h:68:9: remark: floating point conversion changes vector width. Mixed floating point precision requires an up/down cast that will negatively impact performance. [-Rpass-analysis=loop-vectorize]
   68 |         return (float) num;
      |                ^
src/ivfutils.c:287:2: remark: vectorized loop (vectorization width: 16, interleaved count: 4) [-Rpass=loop-vectorize]
  287 |         for (uint32 k = 0; k < VARBITBYTES(vec); k++)
      |         ^
src/ivfutils.c:291:3: remark: loop not vectorized: cannot identify array bounds [-Rpass-analysis=loop-vectorize]
  291 |                 nx[k / 8] |= (x[k] > 0.5 ? 1 : 0) << (7 - (k % 8));
      |                 ^
src/ivfutils.c:322:22: remark: loop not vectorized: cannot identify array bounds [-Rpass-analysis=loop-vectorize]
  322 |                 x[k] += (float) (((VARBITS(vec)[k / 8]) >> (7 - (k % 8))) & 0x01);
      |                                    ^
src/ivfutils.c:321:2: remark: loop not vectorized: could not determine number of loop iterations [-Rpass-analysis=loop-vectorize]
  321 |         for (int k = 0; k < VARBITLEN(vec); k++)
      |         ^
```
