### PR TITLE
Vectorizing vector_concat for improved performance

### DIFF
--- a/src/vector.c
+++ b/src/vector.c
@@ -916,12 +916,11 @@ vector_concat(PG_FUNCTION_ARGS)
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
 	Vector	   *result;
 	int			dim = a->dim + b->dim;
+	const int dim_a = a->dim;
+	const int dim_b = b->dim;
 
 	CheckDim(dim);
 	result = InitVector(dim);
-
-	const int dim_a = a->dim;
-	const int dim_b = b->dim;
 
 	/* Auto-vectorized */
 	for (int i = 0; i < dim_a; i++)

--- a/src/vector.c
+++ b/src/vector.c
@@ -916,8 +916,8 @@ vector_concat(PG_FUNCTION_ARGS)
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
 	Vector	   *result;
 	int			dim = a->dim + b->dim;
-	int dim_a = a->dim;
-	int dim_b = b->dim;
+	int     dim_a = a->dim;
+	int     dim_b = b->dim;
 
 	CheckDim(dim);
 	result = InitVector(dim);

--- a/src/vector.c
+++ b/src/vector.c
@@ -920,11 +920,16 @@ vector_concat(PG_FUNCTION_ARGS)
 	CheckDim(dim);
 	result = InitVector(dim);
 
-	for (int i = 0; i < a->dim; i++)
+	const int dim_a = a->dim;
+	const int dim_b = b->dim;
+
+	/* Auto-vectorized */
+	for (int i = 0; i < dim_a; i++)
 		result->x[i] = a->x[i];
 
-	for (int i = 0; i < b->dim; i++)
-		result->x[i + a->dim] = b->x[i];
+	/* Auto-vectorized */
+	for (int i = 0; i < dim_b; i++)
+		result->x[i + dim_a] = b->x[i];
 
 	PG_RETURN_POINTER(result);
 }

--- a/src/vector.c
+++ b/src/vector.c
@@ -916,8 +916,8 @@ vector_concat(PG_FUNCTION_ARGS)
 	Vector	   *b = PG_GETARG_VECTOR_P(1);
 	Vector	   *result;
 	int			dim = a->dim + b->dim;
-	const int dim_a = a->dim;
-	const int dim_b = b->dim;
+	int dim_a = a->dim;
+	int dim_b = b->dim;
 
 	CheckDim(dim);
 	result = InitVector(dim);


### PR DESCRIPTION
Vectorizing `vector_concat` for some improved performance. On an ARM chip this should generate SIMD instructions to copy the two incoming vectors to the new vector as opposed to doing it all in software.

I'm a little rusty at Assembly so forgive me if I make any mistakes. I used Cursor to help document what each line was doing as a sanity check.

## With the change

The interesting bits are the calls to ARM's `ldp` and `stp` instructions to load/store pairs of CPU registers as opposed to doing them one at a time.

For the first vector copy (a->x to result->x):

```asm
LBB49_6:                                ; =>This Inner Loop Header: Depth=1
    ldp q0, q1, [x11, #-32]            ; Load 4 floats into q0, q1 (16 bytes each)
    ldp q2, q3, [x11], #64             ; Load 4 more floats into q2, q3
    stp q0, q1, [x12, #-32]            ; Store 4 floats from q0, q1
    stp q2, q3, [x12], #64             ; Store 4 more floats from q2, q3
    subs x13, x13, #16                  ; Decrement counter
    b.ne LBB49_6                       ; Loop if not done
```

For the second vector copy (b->x to result->x + a->dim):

```asm
LBB49_18:                               ; =>This Inner Loop Header: Depth=1
    ldp q0, q1, [x11, #-32]            ; Load 4 floats into q0, q1
    ldp q2, q3, [x11], #64             ; Load 4 more floats into q2, q3
    stp q0, q1, [x12, #-32]            ; Store 4 floats from q0, q1
    stp q2, q3, [x12], #64             ; Store 4 more floats from q2, q3
    subs x13, x13, #16                  ; Decrement counter
    b.ne LBB49_18                      ; Loop if not done
```

## Without the change

For the first vector copy (a->x to result->x):

```asm
LBB49_4:                                ; =>This Inner Loop Header: Depth=1
    ldr s0, [x9, x8, lsl #2]           ; Load single float
    str s0, [x10, x8, lsl #2]          ; Store single float
    add x8, x8, #1                     ; Increment counter
    ldrsh x11, [x19, #4]               ; Load dimension
    cmp x8, x11                        ; Compare counter with dimension
    b.lt LBB49_4                       ; Loop if not done
```

For the second vector copy (b->x to result->x + a->dim):

```asm
LBB49_7:                                ; =>This Inner Loop Header: Depth=1
    ldr s0, [x9, x8, lsl #2]           ; Load single float
    ldrsh w11, [x19, #4]               ; Load first vector dimension
    add w11, w8, w11                   ; Calculate offset
    str s0, [x10, w11, sxtw #2]        ; Store single float
    add x8, x8, #1                     ; Increment counter
    ldrsh x11, [x20, #4]               ; Load dimension
    cmp x8, x11                        ; Compare counter with dimension
    b.lt LBB49_7                       ; Loop if not done
```