### PR TITLE
Support sq16 in hnsw access method with vector_cosine_ops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,12 @@ endif
 # - Clang (could use pragma instead) - https://llvm.org/docs/Vectorizers.html
 PG_CFLAGS += $(OPTFLAGS) -ftree-vectorize -fassociative-math -fno-signed-zeros -fno-trapping-math
 
+ARCH := $(shell uname -m)
+ifeq ($(ARCH),x86_64)
+PG_CFLAGS += -mavx512f -mavx512dq  -mavx512vnni
+COMPILE.c.bc = $(CLANG) -Wno-ignored-attributes $(BITCODE_CFLAGS) $(CPPFLAGS) -flto=thin -emit-llvm -c -mavx512f -mavx512dq  -mavx512vnni -ftree-vectorize -fassociative-math -fno-signed-zeros -fno-trapping-math
+endif
+
 # Debug GCC auto-vectorization
 # PG_CFLAGS += -fopt-info-vec
 

--- a/sql/vector.sql
+++ b/sql/vector.sql
@@ -916,3 +916,25 @@ CREATE OPERATOR CLASS sparsevec_l1_ops
 	OPERATOR 1 <+> (sparsevec, sparsevec) FOR ORDER BY float_ops,
 	FUNCTION 1 l1_distance(sparsevec, sparsevec),
 	FUNCTION 3 hnsw_sparsevec_support(internal);
+
+-- TODO:
+-- 1. Move these code into upgrade sql file.
+-- 2. More appropriate location in vector.sql
+CREATE FUNCTION vector_negative_inner_product_avx512(internal, internal) RETURNS float8
+	AS 'MODULE_PATHNAME' LANGUAGE C;
+
+CREATE FUNCTION vector_should_insert_hnsw(vector) RETURNS float8
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION vec_normalize_i16(internal) RETURNS internal
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION sq16_hnsw_vec_support(internal) RETURNS internal
+	AS 'MODULE_PATHNAME' LANGUAGE C;
+
+CREATE OPERATOR CLASS sq16_vector_cosine_ops
+	FOR TYPE vector USING hnsw AS
+	OPERATOR 1 <=> (vector, vector) FOR ORDER BY float_ops,
+	FUNCTION 1 vector_negative_inner_product_avx512(internal, internal),
+	FUNCTION 2 vector_should_insert_hnsw(vector),
+	FUNCTION 3 sq16_hnsw_vec_support(internal);

--- a/src/vector.h
+++ b/src/vector.h
@@ -1,6 +1,8 @@
 #ifndef VECTOR_H
 #define VECTOR_H
 
+#include <stdalign.h>
+
 #define VECTOR_MAX_DIM 16000
 
 #define VECTOR_SIZE(_dim)		(offsetof(Vector, x) + sizeof(float)*(_dim))
@@ -19,6 +21,22 @@ typedef struct Vector
 Vector	   *InitVector(int dim);
 void		PrintVector(char *msg, Vector * vector);
 int			vector_cmp_internal(Vector * a, Vector * b);
+
+#define VECTOR_SIZE_I16(_dim)		(offsetof(VectorI16, x) + sizeof(int16) * (_dim))
+#define DatumGetVectorI16(x)		((VectorI16 *) PG_DETOAST_DATUM(x))
+#define PG_GETARG_VECTORI16_P(x)	DatumGetVectorI16(PG_GETARG_DATUM(x))
+#define PG_RETURN_VECTORI16_P(x)	PG_RETURN_POINTER(x)
+
+typedef struct VectorI16
+{
+	int32				vl_len_;
+	int16				dim;
+	int16				unused;
+	double				dot_product;
+	alignas(64) int16	x[FLEXIBLE_ARRAY_MEMBER];
+} VectorI16;
+
+VectorI16	*InitVectorI16(int dim);
 
 /* TODO Move to better place */
 #if PG_VERSION_NUM >= 160000

--- a/test/t/012_hnsw_vector_build_recall.pl
+++ b/test/t/012_hnsw_vector_build_recall.pl
@@ -3,12 +3,14 @@ use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
+use Config;
 
 my $node;
 my @queries = ();
 my @expected;
 my $limit = 20;
 my $array_sql = join(",", ('random() * random()') x 3);
+my $arch = $Config{archname};
 
 sub test_recall
 {
@@ -70,6 +72,13 @@ for (1 .. 20)
 # Check each index type
 my @operators = ("<->", "<#>", "<=>", "<+>");
 my @opclasses = ("vector_l2_ops", "vector_ip_ops", "vector_cosine_ops", "vector_l1_ops");
+
+if ($arch =~ /x86/)
+{
+	print "x86 arch, run test case for sq16_vector_cosine_ops\n";
+	push(@operators, "<=>");
+	push(@opclasses, "sq16_vector_cosine_ops");
+}
 
 for my $i (0 .. $#operators)
 {

--- a/test/t/013_hnsw_vector_insert_recall.pl
+++ b/test/t/013_hnsw_vector_insert_recall.pl
@@ -3,12 +3,14 @@ use warnings FATAL => 'all';
 use PostgreSQL::Test::Cluster;
 use PostgreSQL::Test::Utils;
 use Test::More;
+use Config;
 
 my $node;
 my @queries = ();
 my @expected;
 my $limit = 20;
 my $array_sql = join(",", ('random() * random()') x 3);
+my $arch = $Config{archname};
 
 sub test_recall
 {
@@ -67,6 +69,13 @@ for (1 .. 20)
 # Check each index type
 my @operators = ("<->", "<#>", "<=>", "<+>");
 my @opclasses = ("vector_l2_ops", "vector_ip_ops", "vector_cosine_ops", "vector_l1_ops");
+
+if ($arch =~ /x86/)
+{
+	print "x86 arch, run test case for sq16_vector_cosine_ops\n";
+	push(@operators, "<=>");
+	push(@opclasses, "sq16_vector_cosine_ops");
+}
 
 for my $i (0 .. $#operators)
 {


### PR DESCRIPTION
Hi pgvector teams,

In this pull request, I would like to add a new operator class family for hnsw access method, and it is used to enhance the performance when conducting vector search based on cosine distance.
# Theory
In the calculation of vector cosine distance, what we focus on is the direction of each vector. That is to say, If a coefficient is multiplied in each dimension of the vector, this will not lead to the final calculation result of the cosine distance, without considering the loss of accuracy. So we can use an int16 to represent the value of each dimension and use the avx512 instruction to optimize the distance calculation function.

This has already been supported and verified to be feasible in some open-source databases, such as mariadb mhnsw index. 
relevant code:
https://github.com/MariaDB/server/blob/main/sql/vector_mhnsw.cc#L898

# Performance
I run ann-benchmark in my test machine with 'dbpedia-openai-1000k-angular' dataset, setup enough large `shared_buffers` and `maintenance_work_mem` to eliminate the impact of disk I/O during index building and vector search phase, and it shows promising results. Under the same recall rate, we achieved a higher qps. 
<img width="979" height="646" alt="image" src="https://github.com/user-attachments/assets/3d6223b4-7a2a-427b-a50c-408891faa32a" />

Moreover, the construction time has been increased from 1517.7 seconds to 936.4 seconds, using the same index build parameter.

In addition, I noticed that hnsw will have a significant performance regression when memory is limited, there are some solutions  for this question, such as PQ. Would the pgvector team like have plans to support them?
