### PR TITLE
Rename array_isspace into scanner_isspace in the comment

### DIFF
--- a/src/vector.c
+++ b/src/vector.c
@@ -130,7 +130,7 @@ InitVector(int dim)
 }
 
 /*
- * Check for whitespace, since array_isspace() is static
+ * Check for whitespace, since scanner_isspace() is static
  */
 static inline bool
 vector_isspace(char ch)


### PR DESCRIPTION
`array_isspace` was removed from PG in https://github.com/postgres/postgres/commit/ae6d06f09684d8f8a7084514c9b35a274babca61

Currently `scanner_isspace` is used everywhere