### PR TITLE
Fix a detail in the tap test case.

### DIFF
--- a/test/t/005_ivfflat_query_recall.pl
+++ b/test/t/005_ivfflat_query_recall.pl
@@ -35,7 +35,7 @@ for my $i (0 .. $#operators)
 		my $query = $node->safe_psql("postgres", "SELECT v FROM tst WHERE i = $id;");
 		my $res = $node->safe_psql("postgres", qq(
 			SET enable_seqscan = off;
-			SELECT v FROM tst ORDER BY v <-> '$query' LIMIT 1;
+			SELECT v FROM tst ORDER BY v '$operator' '$query' LIMIT 1;
 		));
 		is($res, $query);
 	}


### PR DESCRIPTION
Hi pgvector team,

Recently, while writing regression tests for my patch, I discovered an issue. In the test script 005_ivfflat_query_recall.pl, ivfflat vector indexes are created separately for l2_distance, ip_distance, and cosine_distance. However, only the recall results for l2_distance are verified against expected values. This appears to be an oversight, although it likely has minimal impact, I still believe it's worth fixing.