### PR TITLE
Add RISC-V64 architecture support in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ ifneq ($(filter ppc64%, $(shell uname -m)), )
 	OPTFLAGS =
 endif
 
+# RISC-V64 doesn't support -march=native
+ifeq ($(shell uname -m), riscv64)
+	OPTFLAGS =
+endif
+
 # For auto-vectorization:
 # - GCC (needs -ftree-vectorize OR -O3) - https://gcc.gnu.org/projects/tree-ssa/vectorization.html
 # - Clang (could use pragma instead) - https://llvm.org/docs/Vectorizers.html


### PR DESCRIPTION
On RISC-V64 platform, '-march=native' is not supported, so we should use '-march=rv64gc' instead.