### PR TITLE
Optimize sparsevec L1/L2 distance traversal

### DIFF
--- a/src/sparsevec.c
+++ b/src/sparsevec.c
@@ -816,40 +816,38 @@ SparsevecL2SquaredDistance(SparseVector * a, SparseVector * b)
 	float	   *ax = SPARSEVEC_VALUES(a);
 	float	   *bx = SPARSEVEC_VALUES(b);
 	float		distance = 0.0;
-	int			bpos = 0;
+	int			i = 0;
+	int			j = 0;
 
-	for (int i = 0; i < a->nnz; i++)
+	while (i < a->nnz && j < b->nnz)
 	{
 		int			ai = a->indices[i];
-		int			bi = -1;
+		int			bi = b->indices[j];
 
-		for (int j = bpos; j < b->nnz; j++)
+		if (ai == bi)
 		{
-			bi = b->indices[j];
+			float		diff = ax[i] - bx[j];
 
-			if (ai == bi)
-			{
-				float		diff = ax[i] - bx[j];
-
-				distance += diff * diff;
-			}
-			else if (ai > bi)
-				distance += bx[j] * bx[j];
-
-			/* Update start for next iteration */
-			if (ai >= bi)
-				bpos = j + 1;
-
-			/* Found or passed it */
-			if (bi >= ai)
-				break;
+			distance += diff * diff;
+			i++;
+			j++;
 		}
-
-		if (ai != bi)
+		else if (ai < bi)
+		{
 			distance += ax[i] * ax[i];
+			i++;
+		}
+		else
+		{
+			distance += bx[j] * bx[j];
+			j++;
+		}
 	}
 
-	for (int j = bpos; j < b->nnz; j++)
+	for (; i < a->nnz; i++)
+		distance += ax[i] * ax[i];
+
+	for (; j < b->nnz; j++)
 		distance += bx[j] * bx[j];
 
 	return distance;
@@ -1009,38 +1007,38 @@ sparsevec_l1_distance(PG_FUNCTION_ARGS)
 	float	   *ax = SPARSEVEC_VALUES(a);
 	float	   *bx = SPARSEVEC_VALUES(b);
 	float		distance = 0.0;
-	int			bpos = 0;
+	int			i = 0;
+	int			j = 0;
 
 	CheckDims(a, b);
 
-	for (int i = 0; i < a->nnz; i++)
+	while (i < a->nnz && j < b->nnz)
 	{
 		int			ai = a->indices[i];
-		int			bi = -1;
+		int			bi = b->indices[j];
 
-		for (int j = bpos; j < b->nnz; j++)
+		if (ai == bi)
 		{
-			bi = b->indices[j];
-
-			if (ai == bi)
-				distance += fabsf(ax[i] - bx[j]);
-			else if (ai > bi)
-				distance += fabsf(bx[j]);
-
-			/* Update start for next iteration */
-			if (ai >= bi)
-				bpos = j + 1;
-
-			/* Found or passed it */
-			if (bi >= ai)
-				break;
+			distance += fabsf(ax[i] - bx[j]);
+			i++;
+			j++;
 		}
-
-		if (ai != bi)
+		else if (ai < bi)
+		{
 			distance += fabsf(ax[i]);
+			i++;
+		}
+		else
+		{
+			distance += fabsf(bx[j]);
+			j++;
+		}
 	}
 
-	for (int j = bpos; j < b->nnz; j++)
+	for (; i < a->nnz; i++)
+		distance += fabsf(ax[i]);
+
+	for (; j < b->nnz; j++)
 		distance += fabsf(bx[j]);
 
 	PG_RETURN_FLOAT8((double) distance);


### PR DESCRIPTION
## Summary
- Optimize `SparsevecL2SquaredDistance` and `sparsevec_l1_distance` in `src/sparsevec.c` by switching from the previous nested-scan pattern to a linear two-pointer merge traversal over sorted indices.
- Keep `SparsevecInnerProduct` logic unchanged.

## Why this can improve performance
Sparse vectors store sorted indices. A two-pointer merge traversal can reduce control-flow overhead by walking both vectors in a single pass and handling leftovers in straight-line loops.

For L1/L2 distance kernels, this improves the mismatch-heavy path that dominates sparse workloads while preserving exact results.

## Latest benchmark results (PostgreSQL, L1/L2 only)
Bench setup:
- PostgreSQL 14, fresh temp cluster per variant
- `dim = 1,000,000`
- synthetic deterministic sparse data
- 5 measured runs per query (`EXPLAIN (ANALYZE, TIMING OFF)`)
- reverse-order run (`current` first, then `old`) to reduce order/cache bias

Speedup reported as `old / current`:

| nnz | L2 squared speedup | L1 speedup |
| ---: | ---: | ---: |
| 50  | 1.257x | 1.272x |
| 100 | 1.253x | 1.276x |
| 200 | 1.085x | 1.097x |
| 400 | 1.079x | 1.061x |

## Validation
- `make -j4`
- `make installcheck` (all regression tests passed)
