### PR TITLE
Fix reservoir sampling and optimize normalization in ivfflat build

### DIFF
--- a/src/ivfbuild.c
+++ b/src/ivfbuild.c
@@ -62,15 +62,13 @@ AddSample(Datum *values, IvfflatBuildState * buildstate)
 	Datum		value = PointerGetDatum(PG_DETOAST_DATUM(values[0]));
 
 	/*
-	 * Normalize with KMEANS_NORM_PROC since spherical distance function
-	 * expects unit vectors
+	 * Check with KMEANS_NORM_PROC that the value can be normalized
+	 * since spherical distance function expects unit vectors
 	 */
 	if (buildstate->kmeansnormprocinfo != NULL)
 	{
 		if (!IvfflatCheckNorm(buildstate->kmeansnormprocinfo, buildstate->collation, value))
 			return;
-
-		value = IvfflatNormValue(buildstate->typeInfo, buildstate->collation, value);
 	}
 
 	if (samples->length < targsamples)
@@ -147,6 +145,22 @@ SampleRows(IvfflatBuildState * buildstate)
 
 		table_index_build_range_scan(buildstate->heap, buildstate->index, buildstate->indexInfo,
 									 false, true, false, targblock, 1, SampleCallback, (void *) buildstate, NULL);
+	}
+
+	/* Normalize if needed */
+	if (buildstate->kmeansnormprocinfo)
+	{
+		VectorArray samples = buildstate->samples;
+		Datum       value;
+		Datum       nvalue;
+
+		for (int i = 0; i < samples->length; i++)
+		{
+			value  = PointerGetDatum(VectorArrayGet(samples, i));
+			nvalue = IvfflatNormValue(buildstate->typeInfo, buildstate->collation, value);
+			VectorArraySet(samples, i, DatumGetPointer(nvalue));
+			pfree(DatumGetPointer(nvalue));
+		}
 	}
 }
 

--- a/src/ivfbuild.c
+++ b/src/ivfbuild.c
@@ -438,7 +438,7 @@ ComputeCenters(IvfflatBuildState * buildstate)
 	buildstate->samples = VectorArrayInit(numSamples, buildstate->dimensions, buildstate->centers->itemsize);
 	if (buildstate->heap != NULL)
 	{
-		SampleRows(buildstate);
+		IvfflatBench("sample rows", SampleRows(buildstate));
 
 		if (buildstate->samples->length < buildstate->lists)
 		{

--- a/src/ivfbuild.c
+++ b/src/ivfbuild.c
@@ -81,7 +81,7 @@ AddSample(Datum *values, IvfflatBuildState * buildstate)
 	else
 	{
 		if (buildstate->rowstoskip < 0)
-			buildstate->rowstoskip = reservoir_get_next_S(&buildstate->rstate, samples->length, targsamples);
+			buildstate->rowstoskip = reservoir_get_next_S(&buildstate->rstate, buildstate->samplerows, targsamples);
 
 		if (buildstate->rowstoskip <= 0)
 		{
@@ -97,6 +97,8 @@ AddSample(Datum *values, IvfflatBuildState * buildstate)
 
 		buildstate->rowstoskip -= 1;
 	}
+
+	buildstate->samplerows += 1;
 }
 
 /*
@@ -133,6 +135,7 @@ SampleRows(IvfflatBuildState * buildstate)
 	int			targsamples = buildstate->samples->maxlen;
 	BlockNumber totalblocks = RelationGetNumberOfBlocks(buildstate->heap);
 
+	buildstate->samplerows = 0;
 	buildstate->rowstoskip = -1;
 
 	BlockSampler_Init(&buildstate->bs, totalblocks, targsamples, RandomInt());

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -213,6 +213,7 @@ typedef struct IvfflatBuildState
 	/* Sampling */
 	BlockSamplerData bs;
 	ReservoirStateData rstate;
+	double		samplerows;
 	int			rowstoskip;
 
 	/* Sorting */


### PR DESCRIPTION
This PR includes two changes to the `ivfflat` build path.

## Changes

### 1. Fix reservoir sampling

`reservoir_get_next_S()` should use the total number of rows seen so far, rather than the current number of retained samples.

This matches the usage in PostgreSQL, for example in `src/backend/commands/analyze.c:acquire_sample_rows`, and is also consistent with the [reservoir sampling paper](https://dl.acm.org/doi/epdf/10.1145/3147.3165): "Let us denote the number of records processed so far by t."

### 2. Optimize sample normalization

For spherical distance, normalization is unnecessary for rows that are not retained by reservoir sampling.

This change keeps the normalization check during sampling, but defers the actual normalization until after sampling completes, so only retained rows are normalized.

## Testing

### Dataset

100,000 rows from SIFT

### Script

```sql
CREATE EXTENSION IF NOT EXISTS vector;

DROP TABLE IF EXISTS items;

CREATE TABLE items (id int, embedding vector(128));

COPY items(id, embedding) FROM '/tmp/pgvector/sift_base_10w.csv' CSV;

CREATE INDEX ON items USING ivfflat (embedding vector_ip_ops) WITH (lists = 100);
```

### Results

**Without the second change**

<img width="942" height="495" src="https://github.com/user-attachments/assets/927bd5a9-1d95-403c-a676-7b3cf39749c8" />

**With the second change**

<img width="930" height="473" src="https://github.com/user-attachments/assets/6ca6ed75-561b-4ef4-ae7f-4c3ced39f923" />