### PR TITLE
Fix CREATE INDEX CONCURRENTLY crash on ivfflat with assertion-enabled PostgreSQL

### DIFF
--- a/src/ivfbuild.c
+++ b/src/ivfbuild.c
@@ -145,8 +145,14 @@ SampleRows(IvfflatBuildState * buildstate)
 	{
 		BlockNumber targblock = BlockSampler_Next(&buildstate->bs);
 
+		/*
+		 * anyvisible must be false when the scan uses an MVCC snapshot
+		 * (i.e. CREATE INDEX CONCURRENTLY), otherwise PG will assert in
+		 * heapam_index_build_range_scan. Always pass false here, matching
+		 * what table_index_build_scan does internally.
+		 */
 		table_index_build_range_scan(buildstate->heap, buildstate->index, buildstate->indexInfo,
-									 false, true, false, targblock, 1, SampleCallback, (void *) buildstate, NULL);
+									 false, false, false, targblock, 1, SampleCallback, (void *) buildstate, NULL);
 	}
 
 	/* Normalize if needed */


### PR DESCRIPTION
## Problem

Running `CREATE INDEX CONCURRENTLY` on an `ivfflat` index against a PostgreSQL build with assertions enabled (`--enable-cassert`) causes the backend to abort with the following assertion failure:

```
TRAP: failed Assert("snapshot == SnapshotAny || !anyvisible"),
File: ".../backend/access/heap/heapam_handler.c", Line: 1293
```

Backtrace (abridged):

```
ExceptionalCondition
heapam_handler.c:1293                 (heapam_index_build_range_scan)
vector.so  (SampleRows / ComputeCenters / BuildIndex / ivfflatbuild)
index_build
index_concurrently_build
DefineIndex
```

The backend is terminated by `SIGABRT`, the connection is dropped, and the entire instance enters crash recovery. This makes `CREATE INDEX CONCURRENTLY` unusable on assertion-enabled PostgreSQL builds (e.g. development environments using `pgrx`'s `*-debug` toolchains, or any PG built with `--enable-cassert`).

On non-assert (release) builds the assertion is compiled out, so the call returns successfully and the resulting index is correct — the MVCC snapshot used by `CREATE INDEX CONCURRENTLY` already filters out in-progress tuples regardless of the `anyvisible` value, so this is not a data-correctness issue at runtime. The fix is therefore primarily about restoring `CREATE INDEX CONCURRENTLY` on assertion-enabled builds and aligning the call with PostgreSQL's documented API contract.

## Reproduction

Tested against `pg16.8` and `pg17.5` built with `--enable-cassert` (e.g. `pgrx`'s `16.8-debug` / `17.5-debug` toolchains).

```sql
CREATE EXTENSION IF NOT EXISTS vector;

DROP TABLE IF EXISTS items;
CREATE TABLE items (id bigserial PRIMARY KEY, embedding vector(3));
INSERT INTO items (embedding)
SELECT ARRAY[random(), random(), random()]::vector
FROM generate_series(1, 10000);

-- Crashes the backend on assert-enabled builds:
CREATE INDEX CONCURRENTLY items_ivf
  ON items USING ivfflat (embedding vector_l2_ops)
  WITH (lists = 100);
```

The crash reproduces with `max_parallel_maintenance_workers = 0` and `parallel_workers = 0`, ruling out the parallel-build code path.

Server log:

```
DEBUG:  building index "items_ivf" on table "items" serially
TRAP: failed Assert("snapshot == SnapshotAny || !anyvisible") ...
LOG:  server process (PID xxxx) was terminated by signal 6: Aborted
LOG:  terminating any other active server processes
```

## Root cause

In `SampleRows()` (`src/ivfbuild.c`), the call to `table_index_build_range_scan` hard-codes `anyvisible = true`:

```c
table_index_build_range_scan(buildstate->heap, buildstate->index, buildstate->indexInfo,
                             false, true, false, targblock, 1, SampleCallback, (void *) buildstate, NULL);
//                                  ^^^^
//                              anyvisible
```

PostgreSQL's contract for `heapam_index_build_range_scan` is:

```c
Assert(snapshot == SnapshotAny || !anyvisible);
```

That is, `anyvisible = true` is only meaningful when the scan uses `SnapshotAny`. Internally, `heapam_index_build_range_scan` chooses the snapshot based on `IndexInfo->ii_Concurrent`:

- Non-concurrent build → `SnapshotAny` → `anyvisible = true` is valid (and the value is consulted to decide whether to include `INSERT_IN_PROGRESS` / `DELETE_IN_PROGRESS` tuples).
- Concurrent build (`ii_Concurrent = true`) → an MVCC snapshot is registered → the scan goes down a different branch that uses `HeapTupleSatisfiesVisibility` and **never reads `anyvisible`**. Passing `anyvisible = true` here violates the contract.

Because `SampleRows` always passes `anyvisible = true`, the contract is violated under `CREATE INDEX CONCURRENTLY`, producing the assertion failure on debug builds.

The other `table_index_build_scan` call sites in `ivfbuild.c` and `hnswbuild.c` are unaffected — that wrapper internally passes `anyvisible = false`, so only the explicit `table_index_build_range_scan` call in `SampleRows` needs to be fixed.

## Fix

Always pass `anyvisible = false` in the `SampleRows` call, matching what `table_index_build_scan` does internally:

```c
table_index_build_range_scan(buildstate->heap, buildstate->index, buildstate->indexInfo,
                             false, false, false, targblock, 1,
                             SampleCallback, (void *) buildstate, NULL);
```

Behavior:

- Non-concurrent `CREATE INDEX`: scan still uses `SnapshotAny`. With `anyvisible = false`, `INSERT_IN_PROGRESS` / `DELETE_IN_PROGRESS` tuples are no longer fed into sampling, which is the same behavior as `table_index_build_scan` and is the safer default for k-means input.
- `CREATE INDEX CONCURRENTLY`: the assertion is no longer violated and the call now adheres to the documented API contract.

## Verification

Built and installed against `pg16.8 --enable-cassert`. After the fix:

- Serial `CREATE INDEX CONCURRENTLY` on `ivfflat`: succeeds.
- Parallel `CREATE INDEX CONCURRENTLY` on `ivfflat` (`max_parallel_maintenance_workers = 4`, `parallel_workers = 4`): succeeds; debug log shows `using 4 parallel workers` and the build completes normally.
- Regular non-concurrent `CREATE INDEX`: succeeds.
