### PR TITLE
Cap IVFFlat k-means samples to fit maintenance_work_mem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.8.3 (unreleased)
 
+- Reduced IVFFlat index sample memory to fit within `maintenance_work_mem`
 - Fixed performance regression with Hamming distance and Jaccard distance with Postgres 18
 
 ## 0.8.2 (2026-02-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.8.3 (unreleased)
 
-- Reduced IVFFlat index sample memory to fit within `maintenance_work_mem`
+- Capped IVFFlat k-means sample count to respect `maintenance_work_mem`
 - Fixed performance regression with Hamming distance and Jaccard distance with Postgres 18
 
 ## 0.8.2 (2026-02-25)

--- a/src/ivfbuild.c
+++ b/src/ivfbuild.c
@@ -451,9 +451,20 @@ ComputeCenters(IvfflatBuildState * buildstate)
 	/* Skip samples for unlogged table */
 	if (buildstate->heap == NULL)
 		numSamples = 1;
+	else
+	{
+		int			maxSamples = IvfflatMaxKmeansSamples(buildstate->lists, buildstate->dimensions, buildstate->centers->itemsize);
+
+		if (numSamples > maxSamples)
+		{
+			ereport(NOTICE,
+					(errmsg("reducing ivfflat index samples from %d to %d due to maintenance_work_mem", numSamples, maxSamples),
+					 errhint("Increase maintenance_work_mem for better index quality.")));
+			numSamples = maxSamples;
+		}
+	}
 
 	/* Sample rows */
-	/* TODO Ensure within maintenance_work_mem */
 	buildstate->samples = VectorArrayInit(numSamples, buildstate->dimensions, buildstate->centers->itemsize);
 	if (buildstate->heap != NULL)
 	{

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -315,7 +315,7 @@ VectorArraySet(VectorArray arr, int offset, Pointer val)
 /* Methods */
 VectorArray VectorArrayInit(int maxlen, int dimensions, Size itemsize);
 void		VectorArrayFree(VectorArray arr);
-Size		IvfflatKmeansMemoryRequired(int numSamples, int numCenters, int dimensions, Size itemsize, int samplesCapacity);
+Size		IvfflatKmeansMemoryRequired(int numSamples, int numCenters, int dimensions, Size itemsize, Size samplesCapacity);
 int			IvfflatMaxKmeansSamples(int numCenters, int dimensions, Size itemsize);
 void		IvfflatKmeans(Relation index, VectorArray samples, VectorArray centers, const IvfflatTypeInfo * typeInfo);
 FmgrInfo   *IvfflatOptionalProcInfo(Relation index, uint16 procnum);

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -315,6 +315,8 @@ VectorArraySet(VectorArray arr, int offset, Pointer val)
 /* Methods */
 VectorArray VectorArrayInit(int maxlen, int dimensions, Size itemsize);
 void		VectorArrayFree(VectorArray arr);
+Size		IvfflatKmeansMemoryRequired(int numSamples, int numCenters, int dimensions, Size itemsize, int samplesCapacity);
+int			IvfflatMaxKmeansSamples(int numCenters, int dimensions, Size itemsize);
 void		IvfflatKmeans(Relation index, VectorArray samples, VectorArray centers, const IvfflatTypeInfo * typeInfo);
 FmgrInfo   *IvfflatOptionalProcInfo(Relation index, uint16 procnum);
 Datum		IvfflatNormValue(const IvfflatTypeInfo * typeInfo, Oid collation, Datum value);

--- a/src/ivfkmeans.c
+++ b/src/ivfkmeans.c
@@ -19,7 +19,7 @@
  * Estimate memory required for Elkan k-means
  */
 Size
-IvfflatKmeansMemoryRequired(int numSamples, int numCenters, int dimensions, Size itemsize, int samplesCapacity)
+IvfflatKmeansMemoryRequired(int numSamples, int numCenters, int dimensions, Size itemsize, Size samplesCapacity)
 {
 	Size		samplesSize = VECTOR_ARRAY_SIZE(samplesCapacity, itemsize);
 	Size		centersSize = VECTOR_ARRAY_SIZE(numCenters, itemsize);
@@ -38,6 +38,19 @@ IvfflatKmeansMemoryRequired(int numSamples, int numCenters, int dimensions, Size
 }
 
 /*
+ * Report error if k-means memory exceeds maintenance_work_mem
+ */
+static void
+CheckIvfflatKmeansMemory(Size totalSize)
+{
+	if (totalSize > (Size) maintenance_work_mem * 1024L)
+		ereport(ERROR,
+				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+				 errmsg("memory required is %zu MB, maintenance_work_mem is %d MB",
+						totalSize / (1024 * 1024) + 1, maintenance_work_mem / 1024)));
+}
+
+/*
  * Max samples that fit in maintenance_work_mem for k-means
  */
 int
@@ -47,18 +60,25 @@ IvfflatMaxKmeansSamples(int numCenters, int dimensions, Size itemsize)
 	Size		fixed;
 	Size		perSample;
 	Size		avail;
+	Size		maxSamples;
+	Size		minRequired;
 
 	itemsize = MAXALIGN(itemsize);
 
 	fixed = IvfflatKmeansMemoryRequired(0, numCenters, dimensions, itemsize, 0);
 	perSample = itemsize + sizeof(int) + sizeof(float) * numCenters + sizeof(float);
+	minRequired = IvfflatKmeansMemoryRequired(1, numCenters, dimensions, itemsize, 1);
 
-	if (maxMem <= fixed || perSample == 0)
-		return 1;
+	if (maxMem < minRequired)
+		CheckIvfflatKmeansMemory(minRequired);
 
 	avail = maxMem - fixed;
+	maxSamples = avail / perSample;
 
-	return Max(1, (int) Min(avail / perSample, (Size) INT_MAX));
+	if (maxSamples < 1)
+		CheckIvfflatKmeansMemory(minRequired);
+
+	return (int) Min(maxSamples, (Size) INT_MAX);
 }
 
 /*
@@ -323,14 +343,9 @@ ElkanKmeans(Relation index, VectorArray samples, VectorArray centers, const Ivff
 	float	   *newcdist;
 
 	/* Check memory requirements */
-	Size		totalSize = IvfflatKmeansMemoryRequired(numSamples, numCenters, dimensions, centers->itemsize, samples->maxlen);
+	Size		totalSize = IvfflatKmeansMemoryRequired(numSamples, numCenters, dimensions, centers->itemsize, (Size) samples->maxlen);
 
-	/* Add one to error message to ceil */
-	if (totalSize > (Size) maintenance_work_mem * 1024L)
-		ereport(ERROR,
-				(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-				 errmsg("memory required is %zu MB, maintenance_work_mem is %d MB",
-						totalSize / (1024 * 1024) + 1, maintenance_work_mem / 1024)));
+	CheckIvfflatKmeansMemory(totalSize);
 
 	/* Ensure indexing does not overflow */
 	if (numCenters * numCenters > INT_MAX)

--- a/src/ivfkmeans.c
+++ b/src/ivfkmeans.c
@@ -16,6 +16,52 @@
 #endif
 
 /*
+ * Estimate memory required for Elkan k-means
+ */
+Size
+IvfflatKmeansMemoryRequired(int numSamples, int numCenters, int dimensions, Size itemsize, int samplesCapacity)
+{
+	Size		samplesSize = VECTOR_ARRAY_SIZE(samplesCapacity, itemsize);
+	Size		centersSize = VECTOR_ARRAY_SIZE(numCenters, itemsize);
+	Size		newCentersSize = VECTOR_ARRAY_SIZE(numCenters, itemsize);
+	Size		aggSize = sizeof(float) * (int64) numCenters * dimensions;
+	Size		centerCountsSize = sizeof(int) * numCenters;
+	Size		closestCentersSize = sizeof(int) * numSamples;
+	Size		lowerBoundSize = sizeof(float) * numSamples * numCenters;
+	Size		upperBoundSize = sizeof(float) * numSamples;
+	Size		sSize = sizeof(float) * numCenters;
+	Size		halfcdistSize = sizeof(float) * numCenters * numCenters;
+	Size		newcdistSize = sizeof(float) * numCenters;
+
+	return samplesSize + centersSize + newCentersSize + aggSize + centerCountsSize +
+		closestCentersSize + lowerBoundSize + upperBoundSize + sSize + halfcdistSize + newcdistSize;
+}
+
+/*
+ * Max samples that fit in maintenance_work_mem for k-means
+ */
+int
+IvfflatMaxKmeansSamples(int numCenters, int dimensions, Size itemsize)
+{
+	Size		maxMem = (Size) maintenance_work_mem * 1024L;
+	Size		fixed;
+	Size		perSample;
+	Size		avail;
+
+	itemsize = MAXALIGN(itemsize);
+
+	fixed = IvfflatKmeansMemoryRequired(0, numCenters, dimensions, itemsize, 0);
+	perSample = itemsize + sizeof(int) + sizeof(float) * numCenters + sizeof(float);
+
+	if (maxMem <= fixed || perSample == 0)
+		return 1;
+
+	avail = maxMem - fixed;
+
+	return Max(1, (int) Min(avail / perSample, (Size) INT_MAX));
+}
+
+/*
  * Initialize with kmeans++
  *
  * https://theory.stanford.edu/~sergei/papers/kMeansPP-soda.pdf
@@ -276,23 +322,9 @@ ElkanKmeans(Relation index, VectorArray samples, VectorArray centers, const Ivff
 	float	   *halfcdist;
 	float	   *newcdist;
 
-	/* Calculate allocation sizes */
-	Size		samplesSize = VECTOR_ARRAY_SIZE(samples->maxlen, samples->itemsize);
-	Size		centersSize = VECTOR_ARRAY_SIZE(centers->maxlen, centers->itemsize);
-	Size		newCentersSize = VECTOR_ARRAY_SIZE(numCenters, centers->itemsize);
-	Size		aggSize = sizeof(float) * (int64) numCenters * dimensions;
-	Size		centerCountsSize = sizeof(int) * numCenters;
-	Size		closestCentersSize = sizeof(int) * numSamples;
-	Size		lowerBoundSize = sizeof(float) * numSamples * numCenters;
-	Size		upperBoundSize = sizeof(float) * numSamples;
-	Size		sSize = sizeof(float) * numCenters;
-	Size		halfcdistSize = sizeof(float) * numCenters * numCenters;
-	Size		newcdistSize = sizeof(float) * numCenters;
-
-	/* Calculate total size */
-	Size		totalSize = samplesSize + centersSize + newCentersSize + aggSize + centerCountsSize + closestCentersSize + lowerBoundSize + upperBoundSize + sSize + halfcdistSize + newcdistSize;
-
 	/* Check memory requirements */
+	Size		totalSize = IvfflatKmeansMemoryRequired(numSamples, numCenters, dimensions, centers->itemsize, samples->maxlen);
+
 	/* Add one to error message to ceil */
 	if (totalSize > (Size) maintenance_work_mem * 1024L)
 		ereport(ERROR,

--- a/test/t/046_ivfflat_low_memory_samples.pl
+++ b/test/t/046_ivfflat_low_memory_samples.pl
@@ -1,0 +1,27 @@
+use strict;
+use warnings FATAL => 'all';
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+# Initialize node
+my $node = PostgreSQL::Test::Cluster->new('node');
+$node->init;
+$node->start;
+
+# Create table
+$node->safe_psql("postgres", "CREATE EXTENSION vector;");
+$node->safe_psql("postgres", "CREATE TABLE tst (v vector(3));");
+$node->safe_psql("postgres",
+	"INSERT INTO tst SELECT ARRAY[random(), random(), random()] FROM generate_series(1, 100000) i;"
+);
+
+my ($ret, $stdout, $stderr) = $node->psql("postgres", qq(
+	SET client_min_messages = NOTICE;
+	SET maintenance_work_mem = '768kB';
+	CREATE INDEX ON tst USING ivfflat (v vector_l2_ops) WITH (lists = 200);
+));
+ok($ret, 'index build succeeds with low maintenance_work_mem');
+like($stderr, qr/reducing ivfflat index samples from 10000 to \d+ due to maintenance_work_mem/);
+
+done_testing();

--- a/test/t/046_ivfflat_low_memory_samples.pl
+++ b/test/t/046_ivfflat_low_memory_samples.pl
@@ -21,7 +21,49 @@ my ($ret, $stdout, $stderr) = $node->psql("postgres", qq(
 	SET maintenance_work_mem = '768kB';
 	CREATE INDEX ON tst USING ivfflat (v vector_l2_ops) WITH (lists = 200);
 ));
-ok($ret, 'index build succeeds with low maintenance_work_mem');
-like($stderr, qr/reducing ivfflat index samples from 10000 to \d+ due to maintenance_work_mem/);
+ok($ret, 'vector(3) index build succeeds with low maintenance_work_mem');
+like($stderr, qr/reducing ivfflat index samples from 10000 to 735 due to maintenance_work_mem/);
+
+# halfvec uses a smaller item size
+$node->safe_psql("postgres", "CREATE TABLE tst_half (v halfvec(3));");
+$node->safe_psql("postgres",
+	"INSERT INTO tst_half SELECT ARRAY[random(), random(), random()] FROM generate_series(1, 100000) i;"
+);
+
+($ret, $stdout, $stderr) = $node->psql("postgres", qq(
+	SET client_min_messages = NOTICE;
+	SET maintenance_work_mem = '768kB';
+	CREATE INDEX ON tst_half USING ivfflat (v halfvec_l2_ops) WITH (lists = 200);
+));
+ok($ret, 'halfvec(3) index build succeeds with low maintenance_work_mem');
+like($stderr, qr/reducing ivfflat index samples from 10000 to 747 due to maintenance_work_mem/);
+
+# Higher dimensions are common for embeddings
+$node->safe_psql("postgres", "CREATE TABLE tst_large (v vector(1536));");
+$node->safe_psql("postgres", qq(
+	INSERT INTO tst_large
+	SELECT (
+		SELECT array_agg(random()) FROM generate_series(1, 1536)
+	)::vector(1536)
+	FROM generate_series(1, 1000) i;
+));
+
+($ret, $stdout, $stderr) = $node->psql("postgres", qq(
+	SET client_min_messages = NOTICE;
+	SET maintenance_work_mem = '768kB';
+	CREATE INDEX ON tst_large USING ivfflat (v vector_l2_ops) WITH (lists = 10);
+));
+ok($ret, 'vector(1536) index build succeeds with low maintenance_work_mem');
+like($stderr, qr/reducing ivfflat index samples from 10000 to 96 due to maintenance_work_mem/);
+
+# Extremely low maintenance_work_mem should fail fast without a misleading notice
+($ret, $stdout, $stderr) = $node->psql("postgres", qq(
+	SET client_min_messages = NOTICE;
+	SET maintenance_work_mem = '1kB';
+	CREATE INDEX lists200 ON tst USING ivfflat (v vector_l2_ops) WITH (lists = 200);
+));
+ok(!$ret, 'extremely low maintenance_work_mem fails index build');
+like($stderr, qr/memory required is/);
+unlike($stderr, qr/reducing ivfflat index samples/);
 
 done_testing();


### PR DESCRIPTION
Avoid allocating the full sample buffer before k-means when the target sample count would exceed maintenance_work_mem.