### PR TITLE
Fix HNSW index corruption during high INSERT and VACUUM concurrency

### DIFF
--- a/src/hnswvacuum.c
+++ b/src/hnswvacuum.c
@@ -37,6 +37,8 @@ RemoveHeapTids(HnswVacuumState * vacuumstate)
 {
 	BlockNumber blkno = HNSW_HEAD_BLKNO;
 	HnswElement highestPoint = &vacuumstate->highestPoint;
+	HnswElementData fallbackPointData;
+	HnswElement fallbackPoint = &fallbackPointData;
 	Relation	index = vacuumstate->index;
 	BufferAccessStrategy bas = vacuumstate->bas;
 	HnswElement entryPoint = HnswGetEntryPoint(vacuumstate->index);
@@ -44,10 +46,13 @@ RemoveHeapTids(HnswVacuumState * vacuumstate)
 
 	/* Store separately since highestPoint.level is uint8 */
 	int			highestLevel = -1;
+	int			fallbackLevel = -1;
 
-	/* Initialize highest point */
+	/* Initialize highest point and fallback point */
 	highestPoint->blkno = InvalidBlockNumber;
 	highestPoint->offno = InvalidOffsetNumber;
+	fallbackPoint->blkno = InvalidBlockNumber;
+	fallbackPoint->offno = InvalidOffsetNumber;
 
 	while (BlockNumberIsValid(blkno))
 	{
@@ -121,11 +126,25 @@ RemoveHeapTids(HnswVacuumState * vacuumstate)
 			}
 			else if (etup->level > highestLevel && !(entryPoint != NULL && blkno == entryPoint->blkno && offno == entryPoint->offno))
 			{
+				/* Current highest becomes fallback */
+				fallbackPoint->blkno = highestPoint->blkno;
+				fallbackPoint->offno = highestPoint->offno;
+				fallbackPoint->level = highestPoint->level;
+				fallbackLevel = highestLevel;
+
 				/* Keep track of highest non-entry point */
 				highestPoint->blkno = blkno;
 				highestPoint->offno = offno;
 				highestPoint->level = etup->level;
 				highestLevel = etup->level;
+			}
+			else if (etup->level > fallbackLevel && !(entryPoint != NULL && blkno == entryPoint->blkno && offno == entryPoint->offno))
+			{
+				/* Keep track of second highest non-entry point */
+				fallbackPoint->blkno = blkno;
+				fallbackPoint->offno = offno;
+				fallbackPoint->level = etup->level;
+				fallbackLevel = etup->level;
 			}
 		}
 
@@ -137,6 +156,22 @@ RemoveHeapTids(HnswVacuumState * vacuumstate)
 			GenericXLogAbort(state);
 
 		UnlockReleaseBuffer(buf);
+	}
+
+	/*
+	 * Wait for inserts to complete. Inserts before this point may have
+	 * neighbors about to be deleted. Inserts after this point will not.
+	 */
+	LockPage(index, HNSW_UPDATE_LOCK, ExclusiveLock);
+	UnlockPage(index, HNSW_UPDATE_LOCK, ExclusiveLock);
+
+	/* Check if highest point is actually the new entry point */
+	entryPoint = HnswGetEntryPoint(index);
+	if (entryPoint != NULL && highestPoint->blkno == entryPoint->blkno && highestPoint->offno == entryPoint->offno)
+	{
+		highestPoint->blkno = fallbackPoint->blkno;
+		highestPoint->offno = fallbackPoint->offno;
+		highestPoint->level = fallbackPoint->level;
 	}
 }
 
@@ -339,12 +374,7 @@ RepairGraph(HnswVacuumState * vacuumstate)
 	BufferAccessStrategy bas = vacuumstate->bas;
 	BlockNumber blkno = HNSW_HEAD_BLKNO;
 
-	/*
-	 * Wait for inserts to complete. Inserts before this point may have
-	 * neighbors about to be deleted. Inserts after this point will not.
-	 */
-	LockPage(index, HNSW_UPDATE_LOCK, ExclusiveLock);
-	UnlockPage(index, HNSW_UPDATE_LOCK, ExclusiveLock);
+
 
 	/* Repair entry point first */
 	RepairGraphEntryPoint(vacuumstate);

--- a/src/hnswvacuum.c
+++ b/src/hnswvacuum.c
@@ -374,8 +374,6 @@ RepairGraph(HnswVacuumState * vacuumstate)
 	BufferAccessStrategy bas = vacuumstate->bas;
 	BlockNumber blkno = HNSW_HEAD_BLKNO;
 
-
-
 	/* Repair entry point first */
 	RepairGraphEntryPoint(vacuumstate);
 


### PR DESCRIPTION
## Summary

Under high concurrent DML load, HNSW indexes can become corrupted during `VACUUM`. This leads to persistent failures (`different vector dimensions` errors) in subsequent vacuums and and queries which scan the corrupted element. 

The corruption happens when a concurrent `INSERT` promotes a new element to the global entry point during vacuum's first phase (`RemoveHeapTids`). Because `VACUUM` caches a stale view of the entry point, it incorrectly assigns this newly promoted entry point as the `highestPoint` (which should strictly be a non-entry point). This ultimately causes vacuum to skip repairing the entry point, leaving behind a dangling edge.

## Reproduction

This race condition can be reliably reproduced using a GDB script that pauses the vacuum worker during the critical window while running concurrent inserts to force a promotion. 

* **Reproduction Script:** [reproduction.sh](https://gist.github.com/bhagyesh-c/81141580b22261d7eacb20050d4fee77)

It can also be reproduced by heavy concurrent insert/update workloads running alongside vacuum.

## Root Cause

The corruption occurs in three steps:

1. **Phase 1 (`RemoveHeapTids`):** Vacuum scans pages to find a `highestPoint` candidate. It evaluates elements using a cached, stale `entryPoint`. If a concurrent insert promotes a new element to the entry point, `blkno == entryPoint->blkno` evaluates to `false`. Vacuum mistakenly selects this new entry point as the `highestPoint`.
2. **Phase 2 (`RepairGraphEntryPoint`):** Vacuum fetches the true latest entry point (the new element) and calls:
   `RepairGraphElement(vacuumstate, entryPoint, highestPoint);`
   Because `entryPoint` and `highestPoint` are now the exact same element, the safety check inside `RepairGraphElement` triggers and exits immediately. The entry point is left unrepaired and still contains edges pointing to deleted elements.
3. **Phase 3 (`MarkDeleted`):** When these elements are physically zeroed out, the index is left with a dangling edge pointing to a 0-dimension vector.

## Fix

1. **Add a Fallback:** Introduce a `fallbackPoint` inside `RemoveHeapTids` to track a secondary candidate for the highest point.
2. **Shift Synchronization:** Move the `HNSW_UPDATE_LOCK` unlock sequence earlier, from the start of `RepairGraph` to the end of `RemoveHeapTids`. This ensures all in-flight concurrent inserts commit before we verify the entry point.
3. **Safe Demotion:** . We then check the latest `entryPoint`. If it matches our scanned `highestPoint`, we demote `highestPoint` to the `fallbackPoint` so that Phase 2 operates on a valid non-entry point.

## Verification
* The provided reproduction script completes successfully and reports no index corruption.