### PR TITLE
Fix concurrent HNSW insert and vacuum race condition

### DIFF
--- a/src/hnswvacuum.c
+++ b/src/hnswvacuum.c
@@ -584,12 +584,15 @@ MarkDeleted(HnswVacuumState * vacuumstate)
 	BufferAccessStrategy bas = vacuumstate->bas;
 
 	/*
-	 * Wait for index scans to complete. Scans before this point may contain
-	 * tuples about to be deleted. Scans after this point will not, since the
-	 * graph has been repaired.
+	 * Wait for index scans and inserts to complete. Scans and inserts before
+	 * this point may contain tuples about to be deleted. Scans and inserts
+	 * after this point will not, since the graph has been repaired.
 	 */
 	LockPage(index, HNSW_SCAN_LOCK, ExclusiveLock);
 	UnlockPage(index, HNSW_SCAN_LOCK, ExclusiveLock);
+
+	LockPage(index, HNSW_UPDATE_LOCK, ExclusiveLock);
+	UnlockPage(index, HNSW_UPDATE_LOCK, ExclusiveLock);
 
 	while (BlockNumberIsValid(blkno))
 	{


### PR DESCRIPTION
## Summary

HNSW indexes can experience a race condition during concurrent INSERT and VACUUM, which causes INSERT queries to fail with a `cannot load deleted element` error.

The failure happens when an in-flight INSERT caches a deleted element in its candidate list while finding neighbors and traversing the graph, and VACUUM marks the element as deleted before the INSERT has finished evaluating it.

## Reproduction
This race condition can be reproduced using a gdb script that pauses an INSERT worker while VACUUM zeroes out an element that the INSERT has already queued in its candidate list. [Reproduction Script](https://gist.github.com/bhagyesh-c/cf7d73651c3359d11cd57d646ba8d967)

It can also be reproduced by heavy concurrent insert workloads running alongside vacuum.

## Root Cause
The crash occurs because VACUUM's third phase (`MarkDeleted`) physically zeroes out deleted elements when an in-flight INSERT holds a cached copy of the same element. Chronologically:

1. Element A is deleted in the heap.
2. VACUUM completes Phase 1 (`RemoveHeapTids`), and completes `RepairGraphEntryPoint` in Phase 2. 
3. A new INSERT begins, and inside `HnswFindElementNeighbors`, it loads the element A and adds it to the in memory candidate priority queue. INSERT holds `HNSW_UPDATE_LOCK` in Shared mode. (Exception: if there is an entry point promotion during the insert, the lock is upgraded to exclusive and the failure doesn’t occur)
4. VACUUM resumes and completes the remaining phases without any lock conflict.
5. INSERT resumes and tries to load element A which now has `etup->deleted=1`, failing the check:

```c
if (unlikely(etup->deleted))
	elog(ERROR, "cannot load deleted element");
```

## Fix

Introduce an `HNSW_UPDATE_LOCK` barrier alongside the existing scan lock barrier at the start of `MarkDeleted` phase.

## Verification
Reproduction script runs successfully without the insert query failing after the fix is applied.