### PR TITLE
Increase HNSW sparsevec non-zero limit to 1,200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed `hnsw graph not repaired` error with HNSW vacuuming
 - Fixed possible error with inserts during HNSW vacuuming
+- Increased HNSW index limit for `sparsevec` non-zero elements from 1,000 to 1,200
 
 ## 0.8.3 (2026-06-17)
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Supported types are:
 - `vector` - up to 2,000 dimensions
 - `halfvec` - up to 4,000 dimensions
 - `bit` - up to 64,000 dimensions
-- `sparsevec` - up to 1,000 non-zero elements
+- `sparsevec` - up to 1,200 non-zero elements
 
 ### Index Options
 

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -27,7 +27,7 @@ typedef Pointer Item;
 #endif
 
 #define HNSW_MAX_DIM 2000
-#define HNSW_MAX_NNZ 1000
+#define HNSW_MAX_NNZ 1200
 
 /* Support functions */
 #define HNSW_DISTANCE_PROC 1

--- a/test/expected/hnsw_sparsevec.out
+++ b/test/expected/hnsw_sparsevec.out
@@ -101,12 +101,16 @@ SELECT COUNT(*) FROM (SELECT * FROM t ORDER BY val <+> (SELECT NULL::sparsevec))
 
 DROP TABLE t;
 -- non-zero elements
-CREATE TABLE t (val sparsevec(1001));
-INSERT INTO t (val) VALUES (array_fill(1, ARRAY[1001])::vector::sparsevec);
+CREATE TABLE t (val sparsevec(1200));
+INSERT INTO t (val) VALUES (array_fill(1, ARRAY[1200])::vector::sparsevec);
 CREATE INDEX ON t USING hnsw (val sparsevec_l2_ops);
-ERROR:  sparsevec cannot have more than 1000 non-zero elements for hnsw index
+DROP TABLE t;
+CREATE TABLE t (val sparsevec(1201));
+INSERT INTO t (val) VALUES (array_fill(1, ARRAY[1201])::vector::sparsevec);
+CREATE INDEX ON t USING hnsw (val sparsevec_l2_ops);
+ERROR:  sparsevec cannot have more than 1200 non-zero elements for hnsw index
 TRUNCATE t;
 CREATE INDEX ON t USING hnsw (val sparsevec_l2_ops);
-INSERT INTO t (val) VALUES (array_fill(1, ARRAY[1001])::vector::sparsevec);
-ERROR:  sparsevec cannot have more than 1000 non-zero elements for hnsw index
+INSERT INTO t (val) VALUES (array_fill(1, ARRAY[1201])::vector::sparsevec);
+ERROR:  sparsevec cannot have more than 1200 non-zero elements for hnsw index
 DROP TABLE t;

--- a/test/sql/hnsw_sparsevec.sql
+++ b/test/sql/hnsw_sparsevec.sql
@@ -59,10 +59,15 @@ DROP TABLE t;
 
 -- non-zero elements
 
-CREATE TABLE t (val sparsevec(1001));
-INSERT INTO t (val) VALUES (array_fill(1, ARRAY[1001])::vector::sparsevec);
+CREATE TABLE t (val sparsevec(1200));
+INSERT INTO t (val) VALUES (array_fill(1, ARRAY[1200])::vector::sparsevec);
+CREATE INDEX ON t USING hnsw (val sparsevec_l2_ops);
+DROP TABLE t;
+
+CREATE TABLE t (val sparsevec(1201));
+INSERT INTO t (val) VALUES (array_fill(1, ARRAY[1201])::vector::sparsevec);
 CREATE INDEX ON t USING hnsw (val sparsevec_l2_ops);
 TRUNCATE t;
 CREATE INDEX ON t USING hnsw (val sparsevec_l2_ops);
-INSERT INTO t (val) VALUES (array_fill(1, ARRAY[1001])::vector::sparsevec);
+INSERT INTO t (val) VALUES (array_fill(1, ARRAY[1201])::vector::sparsevec);
 DROP TABLE t;


### PR DESCRIPTION
## Summary
- Increase `HNSW_MAX_NNZ` from 1,000 to 1,200 for HNSW indexes on `sparsevec`
- Update regression tests to verify 1,200 succeeds and 1,201 fails (both CREATE INDEX and INSERT paths)
- Update README and CHANGELOG

Fixes #749.

## Motivation
SPLADE sparse embeddings can produce vectors with ~1,100 non-zero elements, which exceed the current HNSW limit while remaining well within the `sparsevec` type limit (16,000).

## Test plan
- [x] `make installcheck REGRESS=hnsw_sparsevec` (requires local Postgres)
- [ ] CI (runs on PR)