### PR TITLE
Skip sample buffer allocation for empty ivfflat tables

### DIFF
--- a/src/ivfbuild.c
+++ b/src/ivfbuild.c
@@ -448,6 +448,17 @@ ComputeCenters(IvfflatBuildState * buildstate)
 	if (buildstate->heap == NULL)
 		numSamples = 1;
 
+	/*
+	 * An empty table has no rows to sample, so avoid allocating (and
+	 * requiring maintenance_work_mem for) the full sample buffer. Without
+	 * this, creating an ivfflat index on an empty table can fail with
+	 * "memory required is N MB, maintenance_work_mem is M MB" even though
+	 * nothing will be sampled - which breaks creating the index in a schema
+	 * migration before data is loaded.
+	 */
+	else if (RelationGetNumberOfBlocks(buildstate->heap) == 0)
+		numSamples = 1;
+
 	/* Sample rows */
 	buildstate->memoryUsed += VECTOR_ARRAY_SIZE(numSamples, buildstate->itemsize);
 	IvfflatCheckMemoryUsage(buildstate->memoryUsed);

--- a/test/expected/ivfflat_vector.out
+++ b/test/expected/ivfflat_vector.out
@@ -173,3 +173,12 @@ ERROR:  0 is outside the valid range for parameter "ivfflat.max_probes" (1 .. 32
 SET ivfflat.max_probes = 32769;
 ERROR:  32769 is outside the valid range for parameter "ivfflat.max_probes" (1 .. 32768)
 DROP TABLE t;
+-- building on an empty table should not require worst-case maintenance_work_mem
+SET maintenance_work_mem = '1MB';
+CREATE TABLE t (val vector(1536));
+CREATE INDEX ON t USING ivfflat (val vector_l2_ops) WITH (lists = 100);
+NOTICE:  ivfflat index created with little data
+DETAIL:  This will cause low recall.
+HINT:  Drop the index until the table has more data.
+DROP TABLE t;
+RESET maintenance_work_mem;

--- a/test/sql/ivfflat_vector.sql
+++ b/test/sql/ivfflat_vector.sql
@@ -97,3 +97,10 @@ SET ivfflat.max_probes = 0;
 SET ivfflat.max_probes = 32769;
 
 DROP TABLE t;
+
+-- building on an empty table should not require worst-case maintenance_work_mem
+SET maintenance_work_mem = '1MB';
+CREATE TABLE t (val vector(1536));
+CREATE INDEX ON t USING ivfflat (val vector_l2_ops) WITH (lists = 100);
+DROP TABLE t;
+RESET maintenance_work_mem;


### PR DESCRIPTION
Fixes #995.

### Problem

`CREATE INDEX ... USING ivfflat` on an **empty table** fails when `maintenance_work_mem` is smaller than the worst-case sample buffer:

```sql
SET maintenance_work_mem = '64MB';
CREATE TABLE t (val vector(1536));
CREATE INDEX ON t USING ivfflat (val vector_cosine_ops) WITH (lists = 300);
-- ERROR: memory required is 90 MB, maintenance_work_mem is 64 MB
```

In `ComputeCenters()` the sample buffer is sized to the worst case (`numSamples = lists * 50`, min 10000) and both allocated and checked *before* `SampleRows()` runs. On an empty table nothing will be sampled, yet the memory check still demands the full buffer. This breaks the common pattern of creating the index in a schema migration before any data is loaded. (It also surfaced when a pinned image moved 0.8.2 → 0.8.4 and CI began failing on migration-time index builds.)

### Fix

An empty heap has nothing to sample, so treat it like the existing unlogged-table case and set `numSamples = 1`. This restores the previous behavior of building the index with the `ivfflat index created with little data` notice, independent of `maintenance_work_mem`. Non-empty tables are unaffected — the sample buffer and memory check are unchanged.

```c
/* Skip samples for unlogged table */
if (buildstate->heap == NULL)
    numSamples = 1;
/* An empty table has no rows to sample ... */
else if (RelationGetNumberOfBlocks(buildstate->heap) == 0)
    numSamples = 1;
```

`RelationGetNumberOfBlocks(buildstate->heap)` is already used in this file (in `SampleRows`), so no new includes.

### Test

Added a case to `test/sql/ivfflat_vector.sql` that builds an ivfflat index on an empty `vector(1536)` table under `maintenance_work_mem = '1MB'`. Without the fix it errors (`memory required is 60 MB, maintenance_work_mem is 1 MB`); with it, the index is created with the little-data notice.

Verified by building the patched extension against 0.8.4 (PG 17.10) and confirming: the empty-table build now succeeds, a populated table still builds an index that the planner uses, and stock 0.8.4 still errors on the same statements.
