### PR TITLE
Fix memory leak in ivfrescan

### DIFF
--- a/src/ivfscan.c
+++ b/src/ivfscan.c
@@ -282,6 +282,7 @@ ivfflatbeginscan(Relation index, int nkeys, int norderbys)
 	so->probes = probes;
 	so->maxProbes = maxProbes;
 	so->dimensions = dimensions;
+	so->value = PointerGetDatum(NULL);
 
 	/* Set support functions */
 	so->procinfo = index_getprocinfo(index, 1, IVFFLAT_DISTANCE_PROC);
@@ -339,6 +340,12 @@ ivfflatrescan(IndexScanDesc scan, ScanKey keys, int nkeys, ScanKey orderbys, int
 	so->first = true;
 	pairingheap_reset(so->listQueue);
 	so->listIndex = 0;
+
+	if (so->normprocinfo != NULL && DatumGetPointer(so->value) != NULL)
+	{
+		pfree(DatumGetPointer(so->value));
+		so->value = PointerGetDatum(NULL);
+	}
 
 	if (keys && scan->numberOfKeys > 0)
 		memmove(scan->keyData, keys, scan->numberOfKeys * sizeof(ScanKeyData));


### PR DESCRIPTION
# Problem
For IVFFlat operator classes with a normalization support function, such as `vector_cosine_ops`, `GetScanValue` allocates a normalized query vector in `so->tmpCtx`.

A parameterized index scan can reuse the same `IndexScanDesc` many times. For example, a nested loop can rescan the IVFFlat index once per outer row. Each rescan then allocates another normalized vector, while the previous allocation remains in `so->tmpCtx` until `ivfflatendscan`.

# Fix

Initialize `so->value` when beginning the scan and release an owned normalized value during rescan, if `normprocinfo` is not null.