### PR TITLE
Fix parallel aggregate failure on empty sets in vector_combine.

### DIFF
--- a/src/vector.c
+++ b/src/vector.c
@@ -1233,7 +1233,9 @@ vector_combine(PG_FUNCTION_ARGS)
 	{
 		n = n2;
 		dim = STATE_DIMS(statearray2);
-		CheckDim(dim);
+		if (n > 0.0) {
+			CheckDim(dim);
+		}
 		statedatums = CreateStateDatums(dim);
 		for (int i = 0; i < dim; i++)
 			statedatums[i + 1] = Float8GetDatum(statevalues2[i + 1]);

--- a/test/expected/vector_type.out
+++ b/test/expected/vector_type.out
@@ -713,7 +713,11 @@ ERROR:  vector_combine: expected state array
 SELECT vector_combine('{0}', '{}');
 ERROR:  vector_combine: expected state array
 SELECT vector_combine('{0}', '{0}');
-ERROR:  vector must have at least 1 dimension
+ vector_combine
+----------------
+ {0}
+(1 row)
+
 SELECT vector_combine('{0}', (SELECT array_agg(n) FROM generate_series(1, 16002) n));
 ERROR:  vector cannot have more than 16000 dimensions
 SELECT vector_combine((SELECT array_agg(n) FROM generate_series(1, 16002) n), '{0}');

--- a/test/t/049_aggregates_empty.pl
+++ b/test/t/049_aggregates_empty.pl
@@ -1,0 +1,34 @@
+use strict;
+use warnings FATAL => 'all';
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+# Initialize node
+my $node = PostgreSQL::Test::Cluster->new('node');
+$node->init;
+$node->start;
+
+# Create table and force parallel execution
+$node->safe_psql("postgres", "CREATE EXTENSION vector;");
+$node->safe_psql("postgres", "CREATE TABLE tst_empty (id int, v vector(3));");
+# Insert enough rows to make parallel scan look attractive
+$node->safe_psql("postgres", "INSERT INTO tst_empty SELECT i, '[1,2,3]' FROM generate_series(1, 1000000) i;");
+
+# Force parallel scanning and aggregation even for subsets
+$node->safe_psql("postgres", "ALTER TABLE tst_empty SET (parallel_workers = 4);");
+
+my $gucs = "SET max_parallel_workers_per_gather = 4; SET min_parallel_table_scan_size = 0; SET parallel_setup_cost = 0; SET parallel_tuple_cost = 0;";
+my $query = "SELECT avg(v) FROM tst_empty WHERE id < 0;";
+
+# Verify it performs a Partial Aggregate
+my $explain = $node->safe_psql("postgres", "$gucs EXPLAIN $query");
+like($explain, qr/Partial Aggregate/, "Query uses Parallel Aggregation");
+
+# Execute the query on empty dataset
+my ($ret, $out, $err) = $node->psql("postgres", "$gucs $query");
+
+is($err, "", "Query should not fail due to CheckDim(0) on empty response from parallel workers");
+is($out, "", "Average of 0 vectors is NULL");
+
+done_testing();


### PR DESCRIPTION
PostgreSQL parallel aggregation uses `INITCOND='{0}'` as the initial working state, resulting in a 0-dimensional float array when a table (or sequential scan shard) contains no rows. When multiple background workers yield empty shards, `vector_combine` erroneously evaluated `CheckDim(0)` on this initialization state, throwing error `vector must have at least 1 dimension` error and failing the query.

This modifies `vector_combine_impl` to conditionally bypass `CheckDim(dim)` only when both incoming parallel states are completely empty (`n == 0.0`), while fully preserving dimensionality checks against malformed inputs in all other code paths.

Also includes a dedicated TAP test to guarantee safety under forced parallel execution limits.