### PR TITLE
Fix two broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ To speed up queries without an index, increase `max_parallel_workers_per_gather`
 SET max_parallel_workers_per_gather = 4;
 ```
 
-If vectors are normalized to length 1 (like [OpenAI embeddings](https://platform.openai.com/docs/guides/embeddings/which-distance-function-should-i-use)), use inner product for best performance.
+If vectors are normalized to length 1 (like [OpenAI embeddings](https://platform.openai.com/docs/guides/embeddings)), use inner product for best performance.
 
 ```tsql
 SELECT * FROM items ORDER BY embedding <#> '[3,1,2]' LIMIT 5;
@@ -1292,7 +1292,7 @@ Thanks to:
 - [Using the Triangle Inequality to Accelerate k-means](https://cdn.aaai.org/ICML/2003/ICML03-022.pdf)
 - [k-means++: The Advantage of Careful Seeding](https://theory.stanford.edu/~sergei/papers/kMeansPP-soda.pdf)
 - [Concept Decompositions for Large Sparse Text Data using Clustering](https://www.cs.utexas.edu/users/inderjit/public_papers/concept_mlj.pdf)
-- [Efficient and Robust Approximate Nearest Neighbor Search using Hierarchical Navigable Small World Graphs](https://arxiv.org/ftp/arxiv/papers/1603/1603.09320.pdf)
+- [Efficient and Robust Approximate Nearest Neighbor Search using Hierarchical Navigable Small World Graphs](https://arxiv.org/abs/1603.09320)
 
 ## History
 


### PR DESCRIPTION
Two links in the README currently return 404. Both were checked with `curl -sL -o /dev/null -w "%{http_code}"`:

| Link | Status |
| --- | --- |
| `https://platform.openai.com/docs/guides/embeddings/which-distance-function-should-i-use` | 404 |
| `https://arxiv.org/ftp/arxiv/papers/1603/1603.09320.pdf` | 404 |

**OpenAI embeddings** (line 726) — the deep link broke when the OpenAI docs were restructured. The guide page it pointed into, `https://platform.openai.com/docs/guides/embeddings`, returns 200.

**HNSW paper** (line 1295) — the legacy `/ftp/arxiv/papers/` path no longer resolves. The canonical `https://arxiv.org/abs/1603.09320` returns 200. If you would rather keep it as a direct PDF link, `https://arxiv.org/pdf/1603.09320` also works — happy to change it.

For completeness, I checked all 93 unique URLs in the README. These were the only two that are actually broken. `https://dl.acm.org/doi/pdf/10.1145/3318464.3386131` returns 403, but that is ACM blocking automated requests rather than a dead link, so I left it untouched.
